### PR TITLE
chore(plugin): clear the two actionable analyzer warnings

### DIFF
--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -615,7 +615,9 @@ namespace MusicBeePlugin.Ffi
 
         private static byte[] CopyParams(IntPtr buf, uint len)
         {
-            if (buf == IntPtr.Zero || len == 0) return new byte[0];
+            // Array.Empty is a shared singleton: safe here because callers only
+            // hand the result to MessagePack, which reads it and never writes.
+            if (buf == IntPtr.Zero || len == 0) return Array.Empty<byte>();
             var bytes = new byte[len];
             Marshal.Copy(buf, bytes, 0, (int)len);
             return bytes;

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
@@ -329,6 +330,11 @@ namespace MusicBeePlugin
         ///     are edited and persisted in the settings dialog, so there is nothing to
         ///     apply here.
         /// </summary>
+        [SuppressMessage(
+            "Performance",
+            "CA1822:Mark members as static",
+            Justification =
+                "MusicBee calls this on the plugin instance through its plugin contract; making it static breaks the entry point.")]
         public void SaveSettings()
         {
         }


### PR DESCRIPTION
Follow-up to #172: the plugin build emitted five analyzer warnings. None were
failing CI - none are in the `WarningsAsErrors` list in `Directory.Build.props`
(lines 39-43), and CA1822 is explicitly parked in `WarningsNotAsErrors`. This
clears the two that are actionable and documents why the other three stay.

## Fixed

**CA1825** - `NativeBridge.CopyParams` returned `new byte[0]` for an empty
payload, allocating on every empty-params callback. Now `Array.Empty<byte>()`.

That returns a shared singleton, so it is only safe if nobody mutates it. Both
callers (`OnQueryData`, `OnExecuteCommand`) pass the array straight to
`_queries.Handle` / `_commands.Handle`, which MessagePack-deserializes it
read-only. Noted in a comment at the site.

## Suppressed, not fixed

**CA1822** on `Plugin.SaveSettings` - MusicBee calls this on the plugin instance
through its plugin contract, so marking it static would break the entry point.
The analyzer cannot see that. It was already in `WarningsNotAsErrors`, so this
conclusion had been reached before but not written down; the `[SuppressMessage]`
justification records it at the site.

## Left alone deliberately

Three **CA1859** "use the concrete type" performance suggestions, all on cold
paths:

- `PluginHost._logger` typed `IPluginLogger` rather than `FfiLogger` - the
  interface is what `NativeBridge`'s constructor takes anyway, and
  devirtualizing a logger field buys nothing measurable.
- `SettingsDialog.BuildButtonRow` / `WrapGroup` returning `Control` rather than
  `TableLayoutPanel` / `GroupBox` - returning `Control` is the point, callers
  only add them to a layout. Both run once, at dialog construction.

## Scope

Only the plugin build's warnings. I have not swept the Rust side
(`clippy -D warnings`) or the test project.

## Testing

`build.ps1 -Plugin` clean, CA1825 and CA1822 confirmed gone from the output.
61 C# tests pass. No behaviour change.
