### PR TITLE
feat(diagnostics): capture a problem into one attachable file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Something in the MusicBee plugin does not work
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this.
+
+        **Before you start, please capture the problem.** In MusicBee, open
+        `Preferences > Plugins > MusicBee Remote > Configure`, find the
+        **Diagnostics** group and press **Start capture**. Reproduce the problem,
+        then press **Stop and save**. A `mbrc-diagnostics-*.zip` appears on your
+        Desktop and Explorer opens with it selected.
+
+        That file carries your plugin and MusicBee versions, your settings, cache
+        health and a detailed log of exactly what went wrong, so nobody has to ask
+        you for any of it. It does **not** contain passwords. It does contain your
+        music folder paths and this PC's local network addresses - open it and look
+        before you attach it. See
+        [docs/troubleshooting.md](https://github.com/musicbeeremote/mbrc-plugin/blob/main/docs/troubleshooting.md)
+        for exactly what is in it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+      placeholder: |
+        The Android app finds my PC, but the library sync stops at about 300 tracks
+        and never finishes. I expected it to sync all 12,000.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What you did, in order. If it only happens sometimes, say how often.
+      placeholder: |
+        1. Open the Android app with the plugin already running
+        2. Pull to refresh the library
+        3. Watch the progress bar stop around 300 tracks
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: diagnostics
+    attributes:
+      label: Diagnostics file
+      description: |
+        Attach the zip by dragging it into the "What happened?" box above. Without
+        it, the first reply is almost always going to be a request for one.
+      options:
+        - label: I have attached a diagnostics zip (Configure > Diagnostics > Start capture)
+        - label: I could not produce one, and I have said why below
+
+  - type: input
+    id: client
+    attributes:
+      label: Which app, and which version?
+      description: The Android or iOS app version, from its own settings screen.
+      placeholder: Android 1.6.1
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: |
+        Shown at the bottom-left of the Configure window. Skip this if you attached a
+        diagnostics zip - it is already in there.
+      placeholder: 1.5.0-beta.2
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Screenshots, when it started, anything that changed on your PC around then.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and setup help
+    url: https://discordapp.com/invite/rceTb57
+    about: Not sure whether it is a bug? Ask on Discord - it is usually faster than an issue.
+  - name: Help pages
+    url: https://mbrc.kelsos.net/help/
+    about: Installing the plugin, connecting a phone, and what the settings do.
+  - name: MusicBee forum thread
+    url: http://getmusicbee.com/forum/index.php?topic=7221.new;topicseen#new
+    about: The long-running thread on the MusicBee forum.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest something the plugin should do
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This tracker is for the **MusicBee plugin** (the Windows half). Requests for
+        the Android or iOS apps belong on their own repositories.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: |
+        The problem rather than the solution. Knowing what you are actually trying to
+        achieve often turns up a better answer than the one being asked for.
+      placeholder: |
+        I keep two libraries and switch between them, and I have to reconnect the
+        phone by hand every time.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like it to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Anything you have tried already?
+      description: Workarounds you use today, or other approaches you considered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ shipped Android and iOS client keeps working untouched.
   selector, and the update controls.
 - `mbrc-helper.exe`, an elevated helper that adds the Windows firewall rule and
   installs updates. It replaces the old firewall utility.
+- A diagnostics capture in the Configure panel. Start it, reproduce a problem,
+  stop it, and the plugin saves one zip to the Desktop with a detailed log of
+  just that window plus the versions, settings and cache health a bug report
+  needs. It raises the log level only for the duration, stops itself after 30
+  minutes, and survives a MusicBee restart so a startup problem can be caught.
+  Proxy credentials are masked and the allowed-address list is left out; nothing
+  is uploaded anywhere. See `docs/troubleshooting.md`.
 
 ### Changed
 - Library browsing is served from an on-disk cache and paged, instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "windows-sys 0.61.2",
+ "zip",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
         ·
         <a href="http://getmusicbee.com/forum/index.php?topic=7221.new;topicseen#new">MusicBee Forum</a>
         ·
-        <a href="https://github.com/musicbeeremote/mbrc-plugin/issues">Report Bug</a>
+        <a href="https://github.com/musicbeeremote/mbrc-plugin/issues/new?template=bug.yml">Report Bug</a>
         ·
-        <a href="https://github.com/musicbeeremote/mbrc-plugin/issues">Request Feature</a>
+        <a href="https://github.com/musicbeeremote/mbrc-plugin/issues/new?template=feature.yml">Request Feature</a>
     </p>
 </p>
 
@@ -30,6 +30,7 @@
   * [Built With](#built-with)
   * [Project Structure](#project-structure)
   * [Documentation](#documentation)
+* [Reporting a Problem](#reporting-a-problem)
 * [Installation](#installation)
 * [Getting Started](#getting-started)
   * [Prerequisites](#prerequisites)
@@ -101,6 +102,18 @@ side-by-side with it.
   and both discovery mechanisms (custom UDP multicast and mDNS / DNS-SD)
 * [`docs/updates.md`](docs/updates.md) - the update mechanism end to end: the
   signed manifest, the channels, staging, and the elevated helper
+* [`docs/troubleshooting.md`](docs/troubleshooting.md) - where the logs live, how
+  to capture a problem, and what the diagnostics file contains
+
+## Reporting a problem
+
+Open the Configure window, press **Start capture** in the Diagnostics group,
+reproduce the problem, then press **Stop and save**. Attach the zip that lands on
+your Desktop to a
+[bug report](https://github.com/musicbeeremote/mbrc-plugin/issues/new?template=bug.yml).
+It carries the versions, settings and detailed log a report needs, so nobody has
+to ask you for them. [`docs/troubleshooting.md`](docs/troubleshooting.md) lists
+exactly what is in it and what is redacted.
 
 ## Installation
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,86 @@
+# Troubleshooting and bug reports
+
+## Capture the problem
+
+The plugin can record a problem while it happens and save everything a bug report
+needs into one file.
+
+1. In MusicBee, open `Preferences > Plugins > MusicBee Remote > Configure`.
+2. In the **Diagnostics** group, press **Start capture**.
+3. Reproduce the problem.
+4. Press **Stop and save**.
+
+A file named `mbrc-diagnostics-<date>-<time>.zip` is written to your Desktop and
+Explorer opens with it selected. Attach it to a
+[bug report](https://github.com/musicbeeremote/mbrc-plugin/issues/new?template=bug.yml).
+
+While a capture runs the plugin logs in much more detail than normal, including
+the messages it exchanges with your phone. That is the point: at the normal
+setting those messages are not recorded at all, so a log taken after the fact
+usually cannot show what went wrong.
+
+A capture stops on its own after 30 minutes, and the log level goes back to
+whatever you had it set to. **Cancel** ends it without saving anything. If
+MusicBee restarts while a capture is running, the capture carries on - which is
+how a problem that only happens at startup gets recorded.
+
+## What is in the file
+
+| Entry | What it is |
+| --- | --- |
+| `report.json` | Versions (plugin, core, MusicBee, Windows, .NET), your settings, the addresses the plugin is listening on, cache health, recently blocked connections, and where the update flow stands |
+| `capture.log` | The plugin's log for the capture window only, not your whole history |
+| `logs/` | Only present when the capture overlapped another log file - because the log rolled partway through, or because MusicBee restarted during it. Log files older than the capture are not included: they predate the problem, and they are the one part of a bundle you could not read before sending it |
+
+**What is removed.** Any username and password in a configured proxy is replaced
+with `<redacted>`, and the list of specifically-allowed client addresses is left
+out. `report.json` lists what was removed under `redacted_keys`.
+
+**What is kept, deliberately.** Your music folder paths, this PC's local network
+addresses, its port, and the addresses of devices that tried to connect. Those are
+readable on purpose: the bugs that most need a diagnostics file are the ones about
+paths, scanning and who is allowed to connect, and stripping them would make the
+file useless for exactly the reports it exists to serve.
+
+Nothing is uploaded anywhere. The plugin writes the file to your Desktop and
+stops; what happens to it next is entirely your decision. Open it and look before
+you attach it to a public issue.
+
+## Where the logs live
+
+Press **Open log folder** in the Configure window's Advanced group, or go to:
+
+```
+%APPDATA%\MusicBee\mb_remote\
+```
+
+- `mbrc-core.log` - the plugin's main log, capped at 10 MB
+- `mbrc-core.1.log.gz` .. `mbrc-core.3.log.gz` - the three previous rolled logs
+- `mbrc-bootstrap.log` - the earliest startup lines, before the main log opens
+- `core_settings.json` - your settings
+
+## Log levels
+
+The **Log level** dropdown in the Advanced group sets what is recorded normally:
+
+- **Normal** - the default. No message-by-message detail.
+- **Debug** - adds the messages exchanged with clients, with long lists sampled.
+- **Trace** - everything, including per-item timings. Verbose enough to roll the
+  log file in minutes on a large library.
+
+You do not need to change this to file a report - a capture raises it for you and
+puts it back. Leave it on Normal unless someone asks otherwise.
+
+## Common problems
+
+**The app cannot find the PC.** Check `report.json`'s `listening.addresses`
+against what the phone is on: they need to be the same network. A VPN on either
+device is the usual culprit. If the addresses look right, the Windows Firewall
+rule may be missing - re-save the settings with "Update firewall rule" ticked.
+
+**Sync starts and stops partway.** Capture it. The log will show whether the
+connection dropped or the library scan stalled, and those have different fixes.
+
+**Covers are missing.** Check `caches.covers_cached` in `report.json`. If it is 0
+or far below your album count, press **Rebuild covers** in the Cache group and
+watch MusicBee's status bar - a first build on a large library takes a while.

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -38,6 +38,12 @@ tracing-subscriber = { version = "=0.3.23", features = ["env-filter"] }
 # gzip for rolled log generations. `rust_backend` (miniz_oxide) is pure Rust, so
 # i686-msvc cross-compiles with no C/zlib toolchain.
 flate2 = { version = "=1.1.9", default-features = false, features = ["rust_backend"] }
+# Writing the diagnostics bundle. Same version and features mbrc-release already
+# pins for reading update zips, so this adds no crate to the graph: mbrc-core
+# takes mbrc-release with `client`, which already compiles zip in. `deflate-flate2`
+# rides on the pure-Rust miniz_oxide above, so i686-msvc stays free of a C
+# toolchain.
+zip = { version = "=8.6.0", default-features = false, features = ["deflate-flate2"] }
 # Cross-platform process RSS for the O(page) memory proof (validation plan): a
 # periodic + per-reconcile log line so a paging sweep on a huge library shows
 # resident memory staying flat. Pure bindings (GetProcessMemoryInfo on Windows),

--- a/packages/mbrc-core/src/diagnostics/bundle.rs
+++ b/packages/mbrc-core/src/diagnostics/bundle.rs
@@ -1,0 +1,331 @@
+//! Writing the diagnostics zip.
+//!
+//! The bundle is written straight to a file in the host-supplied destination,
+//! never handed back across the FFI boundary. Returning the bytes would hold the
+//! whole archive twice - once in a Rust boxed slice, once in a C# `byte[]` - in
+//! a 32-bit process whose address space is already the reason redb's page cache
+//! is capped at 64 MiB.
+
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use time::OffsetDateTime;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+/// What the bundle is built from. Assembled by the caller so this module never
+/// has to reach into the core.
+pub struct Inputs<'a> {
+    /// The core's storage directory - where the logs live.
+    pub storage: &'a str,
+    /// Where the zip goes. Created if it does not exist.
+    pub destination_dir: &'a str,
+    /// The assembled `report.json` body.
+    pub report: Value,
+    /// Byte offset into the active log where the capture began, so the bundle
+    /// carries the reproduction and not the user's whole history.
+    pub log_offset: u64,
+    /// When the capture began, Unix epoch milliseconds (UTC). Bounds which of
+    /// the other log files come along; see [`extra_logs`].
+    pub started_unix_ms: i64,
+}
+
+/// The note written beside a window that had to fall back to the whole file.
+const ROTATED_NOTE: &[u8] = b"The active log rotated during this capture, so capture.log holds \
+the whole current log file rather than only the captured window. The earlier part of the \
+window is in the rolled generations under logs/.\r\n";
+
+/// Build the bundle and return the path written.
+pub fn write(inputs: Inputs<'_>) -> Result<PathBuf, String> {
+    let dir = Path::new(inputs.destination_dir);
+    std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    let path = dir.join(file_name());
+
+    let file = File::create(&path).map_err(|e| format!("create {}: {e}", path.display()))?;
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    let report = serde_json::to_vec_pretty(&inputs.report).map_err(|e| e.to_string())?;
+    add_bytes(&mut zip, "report.json", &report, options)?;
+
+    let (window, rotated) = capture_window(inputs.storage, inputs.log_offset);
+    add_bytes(&mut zip, "capture.log", &window, options)?;
+    if rotated {
+        // Say so in the bundle rather than only in the log: a reader who finds
+        // the window starting mid-session should know why.
+        add_bytes(&mut zip, "capture.log.note.txt", ROTATED_NOTE, options)?;
+    }
+
+    for source in extra_logs(inputs.storage, inputs.started_unix_ms) {
+        let Some(name) = source.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // A log that vanished mid-bundle (a roll landing right now) is skipped,
+        // not fatal - the bundle is still worth producing.
+        let _ = add_file(&mut zip, &format!("logs/{name}"), &source, options);
+    }
+
+    zip.finish().map_err(|e| format!("finish zip: {e}"))?;
+    Ok(path)
+}
+
+/// `mbrc-diagnostics-<utc>.zip`. Second resolution is enough - two captures in
+/// the same second are not a case worth carrying a counter for.
+fn file_name() -> String {
+    let now = OffsetDateTime::now_utc();
+    format!(
+        "mbrc-diagnostics-{:04}{:02}{:02}-{:02}{:02}{:02}.zip",
+        now.year(),
+        now.month() as u8,
+        now.day(),
+        now.hour(),
+        now.minute(),
+        now.second()
+    )
+}
+
+/// The slice of the active log written since the capture began, plus whether the
+/// slice had to fall back to the whole file.
+///
+/// A log shorter than the recorded offset means it rotated mid-capture: the
+/// bytes the offset pointed at are now in a gzipped generation, so the honest
+/// answer is the whole current file plus a note, not a slice into a file that no
+/// longer holds the window.
+fn capture_window(storage: &str, offset: u64) -> (Vec<u8>, bool) {
+    let path = crate::logging::active_log_path(storage);
+    let Ok(mut file) = File::open(&path) else {
+        return (Vec::new(), false);
+    };
+    let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let rotated = len < offset;
+    let start = if rotated { 0 } else { offset };
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return (Vec::new(), rotated);
+    }
+    let mut buf = Vec::new();
+    let _ = file.read_to_end(&mut buf);
+    (buf, rotated)
+}
+
+/// The other log files that overlap the capture window: rolled generations, and
+/// the host-side bootstrap logs.
+///
+/// Bounded by modification time rather than taken wholesale. A rolled generation
+/// only belongs here if the roll happened *during* the capture - then part of the
+/// window really is inside it, which is what `capture.log.note.txt` points at.
+/// One untouched since before the capture is the user's back catalogue: it
+/// predates the reproduction, it was written at the normal log level so it holds
+/// no wire detail anyway, and it is the one part of the bundle nobody can review
+/// before sending it (a gzip inside a zip is not something you can eyeball).
+/// Shipping it by default would undo the slicing `capture.log` exists to do.
+///
+/// The same rule picks up `mbrc-bootstrap.log` exactly when the capture spanned a
+/// restart - which is the case a startup bug needs and no other case does.
+fn extra_logs(storage: &str, started_unix_ms: i64) -> Vec<PathBuf> {
+    let active = crate::logging::active_log_path(storage);
+    let mut paths: Vec<PathBuf> = crate::logging::log_files(storage)
+        .into_iter()
+        // The active log is already in the bundle as capture.log.
+        .filter(|path| path != &active)
+        .collect();
+    for name in ["mbrc-bootstrap.log", "mbrc.log"] {
+        let path = Path::new(storage).join(name);
+        if path.is_file() {
+            paths.push(path);
+        }
+    }
+    paths
+        .into_iter()
+        .filter(|path| touched_since(path, started_unix_ms))
+        .collect()
+}
+
+/// Whether `path` was last written at or after `unix_ms`.
+///
+/// A file whose timestamp cannot be read is included: the failure modes worth
+/// optimizing for are "the maintainer is missing context", not "the bundle is
+/// 900 KB smaller".
+fn touched_since(path: &Path, unix_ms: i64) -> bool {
+    let Ok(modified) = std::fs::metadata(path).and_then(|meta| meta.modified()) else {
+        return true;
+    };
+    match modified.duration_since(std::time::UNIX_EPOCH) {
+        Ok(since_epoch) => since_epoch.as_millis() as i64 >= unix_ms,
+        // Before the epoch: a nonsense timestamp, so fall back to including it.
+        Err(_) => true,
+    }
+}
+
+fn add_bytes(
+    zip: &mut ZipWriter<File>,
+    name: &str,
+    bytes: &[u8],
+    options: SimpleFileOptions,
+) -> Result<(), String> {
+    zip.start_file(name, options)
+        .map_err(|e| format!("start {name}: {e}"))?;
+    zip.write_all(bytes)
+        .map_err(|e| format!("write {name}: {e}"))
+}
+
+fn add_file(
+    zip: &mut ZipWriter<File>,
+    name: &str,
+    source: &Path,
+    options: SimpleFileOptions,
+) -> Result<(), String> {
+    let mut input = File::open(source).map_err(|e| format!("open {}: {e}", source.display()))?;
+    zip.start_file(name, options)
+        .map_err(|e| format!("start {name}: {e}"))?;
+    io::copy(&mut input, zip).map_err(|e| format!("copy {name}: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch storage dir seeded with an active log and one rolled generation.
+    fn seed(case: &str, log_body: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mbrc-bundle-{case}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        std::fs::write(dir.join("mbrc-core.log"), log_body).expect("seed log");
+        std::fs::write(dir.join("mbrc-core.1.log.gz"), b"stand-in for a rolled log")
+            .expect("seed rolled log");
+        dir
+    }
+
+    fn entries(zip_path: &Path) -> Vec<String> {
+        let file = File::open(zip_path).expect("open bundle");
+        let mut archive = zip::ZipArchive::new(file).expect("read bundle");
+        (0..archive.len())
+            .map(|i| archive.by_index(i).expect("entry").name().to_owned())
+            .collect()
+    }
+
+    fn read_entry(zip_path: &Path, name: &str) -> String {
+        let file = File::open(zip_path).expect("open bundle");
+        let mut archive = zip::ZipArchive::new(file).expect("read bundle");
+        let mut entry = archive.by_name(name).expect("entry present");
+        let mut body = String::new();
+        entry.read_to_string(&mut body).expect("read entry");
+        body
+    }
+
+    #[test]
+    fn bundle_holds_the_report_the_window_and_overlapping_rolled_logs() {
+        let dir = seed("contents", "before the capture\nafter the capture\n");
+        let out = dir.join("out");
+        let path = write(Inputs {
+            storage: dir.to_str().expect("utf8 dir"),
+            destination_dir: out.to_str().expect("utf8 dir"),
+            report: serde_json::json!({ "versions": { "core": "1.5.0" } }),
+            log_offset: "before the capture\n".len() as u64,
+            // Epoch: everything in the scratch dir counts as written during the
+            // capture, which is the overlap this case is about.
+            started_unix_ms: 0,
+        })
+        .expect("bundle written");
+
+        let names = entries(&path);
+        assert!(names.contains(&"report.json".to_owned()), "{names:?}");
+        assert!(names.contains(&"capture.log".to_owned()), "{names:?}");
+        assert!(
+            names.contains(&"logs/mbrc-core.1.log.gz".to_owned()),
+            "{names:?}"
+        );
+        // The active log must not be duplicated under logs/.
+        assert!(
+            !names.contains(&"logs/mbrc-core.log".to_owned()),
+            "{names:?}"
+        );
+
+        // The window is only what was logged after the capture began.
+        assert_eq!(read_entry(&path, "capture.log"), "after the capture\n");
+
+        // And the report survives the round trip as parseable JSON.
+        let report: Value =
+            serde_json::from_str(&read_entry(&path, "report.json")).expect("report.json parses");
+        assert_eq!(report["versions"]["core"], "1.5.0");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_rotation_mid_capture_falls_back_to_the_whole_file_with_a_note() {
+        let dir = seed("rotated", "a fresh, short log\n");
+        let out = dir.join("out");
+        let path = write(Inputs {
+            storage: dir.to_str().expect("utf8 dir"),
+            destination_dir: out.to_str().expect("utf8 dir"),
+            report: Value::Null,
+            // Far past the end: what a rotation looks like from here.
+            log_offset: 10_000,
+            started_unix_ms: 0,
+        })
+        .expect("bundle written");
+
+        assert_eq!(read_entry(&path, "capture.log"), "a fresh, short log\n");
+        assert!(entries(&path).contains(&"capture.log.note.txt".to_owned()));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rolled_logs_from_before_the_capture_are_left_out() {
+        // The user's back catalogue is not part of the reproduction, and it is
+        // the part of the bundle they cannot review before sending it.
+        let dir = seed(
+            "stale-rolls",
+            "the whole log
+",
+        );
+        let out = dir.join("out");
+        let path = write(Inputs {
+            storage: dir.to_str().expect("utf8 dir"),
+            destination_dir: out.to_str().expect("utf8 dir"),
+            report: Value::Null,
+            log_offset: 0,
+            // The capture began well after the seeded files were written.
+            started_unix_ms: 4_102_444_800_000,
+        })
+        .expect("bundle written");
+
+        let names = entries(&path);
+        assert!(
+            !names.iter().any(|name| name.starts_with("logs/")),
+            "stale logs should not travel: {names:?}"
+        );
+        // The window itself still does.
+        assert_eq!(
+            read_entry(&path, "capture.log"),
+            "the whole log
+"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_log_still_produces_a_bundle() {
+        // A capture on a fresh install, before anything was logged.
+        let dir = std::env::temp_dir().join("mbrc-bundle-nolog");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let out = dir.join("out");
+        let path = write(Inputs {
+            storage: dir.to_str().expect("utf8 dir"),
+            destination_dir: out.to_str().expect("utf8 dir"),
+            report: serde_json::json!({}),
+            log_offset: 0,
+            started_unix_ms: 0,
+        })
+        .expect("bundle written");
+
+        assert_eq!(read_entry(&path, "capture.log"), "");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/packages/mbrc-core/src/diagnostics/capture.rs
+++ b/packages/mbrc-core/src/diagnostics/capture.rs
@@ -1,0 +1,876 @@
+//! The capture session: one at a time, owned by the core.
+//!
+//! A capture raises the log level to debug for the session only, remembers where
+//! in the log it began, and ends by writing a bundle sliced to that window. The
+//! core owns it rather than the host because there is no transient-setting
+//! concept on the C# side: the only way it can change the log level is a
+//! `WriteSettings` that persists it, and a level pushed without one is reverted
+//! by the next core reload.
+//!
+//! Two rules keep it honest:
+//!
+//! - **One capture at a time.** A second start while one runs is refused, not
+//!   queued - two overlapping windows would make the offset a lie.
+//! - **A capture always ends.** A safety auto-stop restores the level after
+//!   [`MAX_CAPTURE`], so a user who forgets does not leave the plugin writing
+//!   debug logs until MusicBee closes.
+//!
+//! The session survives a MusicBee restart (it is recorded in `capture.json`),
+//! because "it breaks on startup" is exactly the bug that most needs capturing
+//! and the log file is appended across restarts rather than truncated.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::LogLevel;
+use crate::diagnostics::{bundle, report};
+use crate::ffi::dtos::{CaptureEnvEntry, CaptureRequest, CaptureStatus};
+use crate::ffi::types::{HostEventType, MbrcResult};
+use crate::state::Core;
+
+/// Nothing is being captured and nothing has been this session.
+pub const CAPTURE_IDLE: &str = "idle";
+/// A capture is running; the log is at debug level.
+pub const CAPTURE_CAPTURING: &str = "capturing";
+/// The capture ended and the bundle is being written.
+pub const CAPTURE_WRITING: &str = "writing";
+/// A bundle was written; `bundle_path` names it.
+pub const CAPTURE_DONE: &str = "done";
+/// The safety auto-stop ended a capture nobody stopped.
+pub const CAPTURE_EXPIRED: &str = "expired";
+/// The capture or the bundle failed; `message` says how, and so does the log.
+pub const CAPTURE_ERROR: &str = "error";
+
+/// How long a capture may run before it stops itself. Long enough to reproduce
+/// anything a user can reproduce on purpose, short enough that a forgotten
+/// capture cannot fill the 10 MiB x 3 log budget with debug output.
+const MAX_CAPTURE: Duration = Duration::from_secs(30 * 60);
+
+/// How often the watchdog re-checks. Coarse on purpose: it exists to bound a
+/// forgotten capture, not to stop one on the second.
+const WATCHDOG_TICK: Duration = Duration::from_secs(5);
+
+/// Where a running capture is recorded, so it survives a MusicBee restart.
+const CAPTURE_FILE: &str = "capture.json";
+
+/// A running capture.
+struct Session {
+    /// Distinguishes this capture from any later one, so a watchdog thread whose
+    /// capture already ended does nothing when it wakes.
+    generation: u64,
+    started_unix_ms: i64,
+    /// Monotonic start, for the auto-stop. Separate from `started_unix_ms`
+    /// because a wall-clock jump must not shorten or extend a capture.
+    started: Instant,
+    log_offset: u64,
+    host_environment: Vec<CaptureEnvEntry>,
+}
+
+/// What a capture leaves behind once it ends, plus the running one if any.
+struct State {
+    session: Option<Session>,
+    /// The state to report when no session is running.
+    resting: &'static str,
+    bundle_path: String,
+    message: String,
+}
+
+static STATE: Mutex<State> = Mutex::new(State {
+    session: None,
+    resting: CAPTURE_IDLE,
+    bundle_path: String::new(),
+    message: String::new(),
+});
+
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+
+fn lock() -> MutexGuard<'static, State> {
+    STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The on-disk record of a running capture. Only what a restart cannot
+/// reconstruct: the wall-clock start, the offset, and what the host told us.
+#[derive(Serialize, Deserialize)]
+struct Persisted {
+    started_unix_ms: i64,
+    log_offset: u64,
+    #[serde(default)]
+    host_environment: Vec<CaptureEnvEntry>,
+}
+
+/// Begin a capture. Refused while one is already running.
+pub fn start(core: &Core, request: CaptureRequest) -> MbrcResult {
+    let storage = core.config.storage_path.clone();
+    let mut guard = lock();
+    if guard.session.is_some() {
+        return MbrcResult::AlreadyRunning;
+    }
+
+    let session = Session {
+        generation: GENERATION.fetch_add(1, Ordering::AcqRel) + 1,
+        started_unix_ms: now_unix_ms(),
+        started: Instant::now(),
+        log_offset: log_len(&storage),
+        host_environment: request.host_environment,
+    };
+    let generation = session.generation;
+    persist(&storage, &session);
+    guard.session = Some(session);
+    guard.resting = CAPTURE_IDLE;
+    guard.message = String::new();
+    drop(guard);
+
+    raise_level(core);
+    tracing::info!("diagnostics capture started");
+    spawn_watchdog(generation, MAX_CAPTURE);
+    emit(core);
+    MbrcResult::Ok
+}
+
+/// End the capture and write the bundle in the background.
+///
+/// The write is off-thread for the same reason the update flow's are: the host
+/// calls this from MusicBee's UI thread, and zipping tens of megabytes of log
+/// would freeze it. The panel learns the outcome from the status event.
+pub fn stop(core: std::sync::Arc<Core>, request: &CaptureRequest) -> MbrcResult {
+    let mut guard = lock();
+    let Some(session) = guard.session.take() else {
+        return MbrcResult::InvalidArgument;
+    };
+    guard.resting = CAPTURE_WRITING;
+    drop(guard);
+
+    // Back to the user's chosen level first: whatever happens to the bundle, the
+    // capture itself is over.
+    restore_level(&core);
+    clear_persisted(&core.config.storage_path);
+    emit(&core);
+
+    let destination = request.destination_dir.clone();
+    std::thread::spawn(move || {
+        // Zipping tens of megabytes takes seconds, and the C# callback delegates
+        // are released at `mbrc_shutdown` - which a user pressing Stop and then
+        // immediately closing MusicBee (or saving a port change, which re-inits
+        // the core) reaches well inside that window. The report reads the plugin
+        // version back through the host, so this is checked before the build, not
+        // just before the event. Narrows the window rather than closing it,
+        // exactly as the update jobs do.
+        if !crate::state::is_initialized() {
+            tracing::warn!("skipping the diagnostics bundle: the core shut down first");
+            lock().resting = CAPTURE_IDLE;
+            return;
+        }
+        finish(&core, &session, &destination);
+    });
+    MbrcResult::Ok
+}
+
+/// Build the bundle and record the outcome. Split out of the thread body in
+/// [`stop`] so the shutdown guard and the work it guards can be exercised
+/// separately - a test builds a `Core` directly rather than through
+/// `state::initialize`, so it never satisfies that guard.
+fn finish(core: &Core, session: &Session, destination: &str) {
+    let outcome = build_bundle(core, session, destination);
+    let mut guard = lock();
+    match outcome {
+        Ok(path) => {
+            tracing::info!(path = %path, "diagnostics bundle written");
+            guard.resting = CAPTURE_DONE;
+            guard.bundle_path = path;
+            guard.message = String::new();
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "diagnostics bundle failed");
+            guard.resting = CAPTURE_ERROR;
+            guard.message = error;
+        }
+    }
+    drop(guard);
+    // Re-checked: the build is the slow part, so a shutdown is likelier to have
+    // landed by now than it was before it.
+    if crate::state::is_initialized() {
+        emit(core);
+    }
+}
+
+/// Abandon the capture: restore the level and write nothing.
+pub fn cancel(core: &Core) -> MbrcResult {
+    let mut guard = lock();
+    if guard.session.take().is_none() {
+        return MbrcResult::InvalidArgument;
+    }
+    guard.resting = CAPTURE_IDLE;
+    guard.message = String::new();
+    drop(guard);
+
+    restore_level(core);
+    clear_persisted(&core.config.storage_path);
+    tracing::info!("diagnostics capture cancelled");
+    emit(core);
+    MbrcResult::Ok
+}
+
+/// The current status. Always an answer, even before anything has run.
+pub fn status() -> CaptureStatus {
+    let guard = lock();
+    match &guard.session {
+        Some(session) => CaptureStatus {
+            state: CAPTURE_CAPTURING.to_owned(),
+            started_unix_ms: session.started_unix_ms,
+            seconds_remaining: MAX_CAPTURE
+                .saturating_sub(session.started.elapsed())
+                .as_secs() as i32,
+            bundle_path: guard.bundle_path.clone(),
+            message: String::new(),
+        },
+        None => CaptureStatus {
+            state: guard.resting.to_owned(),
+            started_unix_ms: 0,
+            seconds_remaining: 0,
+            bundle_path: guard.bundle_path.clone(),
+            message: guard.message.clone(),
+        },
+    }
+}
+
+/// Serialize the status as MessagePack for the settings panel.
+pub fn status_bytes() -> Option<Vec<u8>> {
+    rmp_serde::to_vec_named(&status()).ok()
+}
+
+/// Resume a capture that a MusicBee restart interrupted.
+///
+/// Called once from init. The log file is appended across restarts rather than
+/// truncated, so the original offset still points at the start of the window and
+/// the capture simply continues - which is the whole reason a startup bug can be
+/// captured at all. A record older than [`MAX_CAPTURE`] is dropped instead:
+/// resuming it would immediately expire.
+pub fn resume_after_restart(core: &Core) {
+    // A settings save that changes the port re-inits the core in-process
+    // (`mbrc_shutdown` + `mbrc_initialize`), and shutdown does not clear this
+    // module's state - so without this the live session would be replayed over
+    // itself: a second watchdog, a bumped generation, and the status reset
+    // mid-capture.
+    // Scoped so the guard is unmistakably released before the lock is taken
+    // again below - this mutex is not reentrant.
+    {
+        let guard = lock();
+        if guard.session.is_some() {
+            return;
+        }
+    }
+
+    let storage = &core.config.storage_path;
+    let Some(persisted) = read_persisted(storage) else {
+        return;
+    };
+    let age_ms = now_unix_ms()
+        .saturating_sub(persisted.started_unix_ms)
+        .max(0);
+    let remaining = MAX_CAPTURE.saturating_sub(Duration::from_millis(age_ms as u64));
+    if remaining.is_zero() {
+        tracing::info!("dropping a diagnostics capture that outlived its window");
+        clear_persisted(storage);
+        return;
+    }
+
+    let session = Session {
+        generation: GENERATION.fetch_add(1, Ordering::AcqRel) + 1,
+        started_unix_ms: persisted.started_unix_ms,
+        // Rebased onto this process's clock, with the elapsed time already spent
+        // taken off, so the auto-stop still fires 30 minutes after the capture
+        // began rather than 30 minutes after the restart.
+        //
+        // `checked_sub`, not `-`: on Windows an `Instant` counts from boot, and
+        // the restart being resumed through is very often a *reboot*. Subtracting
+        // four minutes of elapsed capture from a machine that has been up for one
+        // would underflow, and plain `Sub` panics on that - inside
+        // `mbrc_initialize`, which would report the whole plugin as failed to
+        // start while the core was in fact already up. Falling back to now just
+        // gives the resumed capture its full window again.
+        started: Instant::now()
+            .checked_sub(MAX_CAPTURE - remaining)
+            .unwrap_or_else(Instant::now),
+        log_offset: persisted.log_offset,
+        host_environment: persisted.host_environment,
+    };
+    let generation = session.generation;
+    let mut guard = lock();
+    guard.session = Some(session);
+    guard.resting = CAPTURE_IDLE;
+    drop(guard);
+
+    raise_level(core);
+    tracing::info!(
+        remaining_secs = remaining.as_secs(),
+        "resumed a diagnostics capture across a restart"
+    );
+    spawn_watchdog(generation, remaining);
+}
+
+/// Assemble the report and hand it to the bundle writer.
+fn build_bundle(core: &Core, session: &Session, destination: &str) -> Result<String, String> {
+    if destination.trim().is_empty() {
+        return Err("no destination folder was given for the bundle".to_owned());
+    }
+    let report = report::build(core, &session.host_environment, session.started_unix_ms);
+    let path = bundle::write(bundle::Inputs {
+        storage: &core.config.storage_path,
+        destination_dir: destination,
+        report,
+        log_offset: session.log_offset,
+        started_unix_ms: session.started_unix_ms,
+    })?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// End a capture that nobody stopped, restoring the log level.
+///
+/// Deliberately does not write a bundle: there is no destination to write it to
+/// (the host supplies that on stop), and a user who walked away is not waiting
+/// for a file. The window is still in the log if they want to try again.
+fn expire(generation: u64) {
+    let mut guard = lock();
+    match &guard.session {
+        // A newer capture, or none - this watchdog outlived its session.
+        Some(session) if session.generation != generation => return,
+        None => return,
+        Some(_) => {}
+    }
+    guard.session = None;
+    guard.resting = CAPTURE_EXPIRED;
+    guard.message = format!(
+        "The capture stopped itself after {} minutes and the log level went back to normal.",
+        MAX_CAPTURE.as_secs() / 60
+    );
+    drop(guard);
+
+    // After a shutdown there is no core to restore the level on, and no host to
+    // tell - the process is going away with it either way.
+    if let Some(core) = crate::state::core_handle() {
+        restore_level(&core);
+        clear_persisted(&core.config.storage_path);
+        tracing::warn!("diagnostics capture stopped itself after reaching its time limit");
+        emit(&core);
+    }
+}
+
+/// Watch a capture and expire it once `remaining` has passed.
+///
+/// A thread rather than a lazy check on the next query: with the panel closed
+/// nothing queries, and the whole point is to bound a capture the user forgot.
+fn spawn_watchdog(generation: u64, remaining: Duration) {
+    std::thread::spawn(move || {
+        let deadline = Instant::now() + remaining;
+        loop {
+            std::thread::sleep(WATCHDOG_TICK);
+            // Cheap early exit for the normal case: the capture was stopped, so
+            // this thread has nothing left to guard.
+            let still_running = {
+                let guard = lock();
+                matches!(&guard.session, Some(s) if s.generation == generation)
+            };
+            if !still_running {
+                return;
+            }
+            if Instant::now() >= deadline {
+                expire(generation);
+                return;
+            }
+        }
+    });
+}
+
+/// Raise the log level for the capture, without ever lowering it: a user already
+/// running at trace asked for more than debug, and a capture should not take it
+/// away.
+fn raise_level(core: &Core) {
+    let level = match core.config.log_level {
+        LogLevel::Trace => LogLevel::Trace,
+        _ => LogLevel::Debug,
+    };
+    apply_level(level);
+}
+
+/// Put the level back to whatever the user has saved.
+fn restore_level(core: &Core) {
+    apply_level(core.config.log_level);
+}
+
+fn apply_level(level: LogLevel) {
+    if let Err(error) = crate::logging::set_level(directive_for(level)) {
+        tracing::warn!(error = %error, "could not change the log level for the capture");
+    }
+}
+
+/// The tracing directive for a settings log level. Mirrors the host's own
+/// mapping in `NativeBridge.SetLogLevel`, so a level set here and a level set
+/// there mean the same thing.
+fn directive_for(level: LogLevel) -> &'static str {
+    match level {
+        LogLevel::Trace => "info,mbrc_core=trace,mbrc=trace",
+        LogLevel::Debug => "info,mbrc_core=debug,mbrc=debug",
+        LogLevel::Info => "mbrc_core=info,info",
+    }
+}
+
+/// Tell an open panel to re-query. Best effort: no host callback, no event.
+fn emit(core: &Core) {
+    core.providers
+        .emit_event(HostEventType::CaptureStatusChanged, &[]);
+}
+
+/// Current length of the active log - where a capture's window begins.
+fn log_len(storage: &str) -> u64 {
+    std::fs::metadata(crate::logging::active_log_path(storage))
+        .map(|meta| meta.len())
+        .unwrap_or(0)
+}
+
+fn capture_file(storage: &str) -> std::path::PathBuf {
+    std::path::Path::new(storage).join(CAPTURE_FILE)
+}
+
+/// Record the running capture. A failure here is logged and tolerated: it costs
+/// the restart-survival, not the capture.
+fn persist(storage: &str, session: &Session) {
+    if storage.is_empty() {
+        return;
+    }
+    let record = Persisted {
+        started_unix_ms: session.started_unix_ms,
+        log_offset: session.log_offset,
+        host_environment: session.host_environment.clone(),
+    };
+    let written = serde_json::to_string_pretty(&record)
+        .map_err(|e| e.to_string())
+        .and_then(|body| std::fs::write(capture_file(storage), body).map_err(|e| e.to_string()));
+    if let Err(error) = written {
+        tracing::warn!(error = %error, "could not record the capture; it will not survive a restart");
+    }
+}
+
+fn read_persisted(storage: &str) -> Option<Persisted> {
+    if storage.is_empty() {
+        return None;
+    }
+    let body = std::fs::read_to_string(capture_file(storage)).ok()?;
+    match serde_json::from_str(&body) {
+        Ok(record) => Some(record),
+        Err(error) => {
+            tracing::warn!(error = %error, "ignoring an unreadable capture record");
+            let _ = std::fs::remove_file(capture_file(storage));
+            None
+        }
+    }
+}
+
+fn clear_persisted(storage: &str) {
+    if storage.is_empty() {
+        return;
+    }
+    let _ = std::fs::remove_file(capture_file(storage));
+}
+
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes the tests that drive the module's global session state.
+    ///
+    /// `STATE` is deliberately process-global - a plugin runs one capture, not
+    /// one per caller - so tests that start, stop or expire a capture fight over
+    /// it when cargo runs them on separate threads. Same hazard `state.rs` notes
+    /// about its own global; it folds its cases into one test, this takes a lock
+    /// so the cases keep their own names.
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    fn exclusive() -> MutexGuard<'static, ()> {
+        TEST_GUARD
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Reset the module's global between tests, which share the process.
+    fn reset() {
+        let mut guard = lock();
+        guard.session = None;
+        guard.resting = CAPTURE_IDLE;
+        guard.bundle_path = String::new();
+        guard.message = String::new();
+    }
+
+    #[test]
+    fn status_is_idle_before_anything_runs() {
+        let _exclusive = exclusive();
+        reset();
+        let status = status();
+        assert_eq!(status.state, CAPTURE_IDLE);
+        assert_eq!(status.started_unix_ms, 0);
+        assert_eq!(status.seconds_remaining, 0);
+    }
+
+    #[test]
+    fn status_round_trips_as_named_msgpack() {
+        let _exclusive = exclusive();
+        // Locks the serialization the C# contractless resolver reads by name;
+        // to_vec (positional) would deserialize as a fixarray and break the
+        // panel at runtime, which no serde round-trip test would catch.
+        reset();
+        let bytes = status_bytes().expect("status serializes");
+        let back: CaptureStatus = rmp_serde::from_slice(&bytes).expect("named map decodes");
+        assert_eq!(back.state, CAPTURE_IDLE);
+        // A map, not an array: msgpack fixmap codes are 0x80..=0x8f.
+        assert!(
+            (0x80..=0x8f).contains(&bytes[0]),
+            "expected a fixmap, got {:#04x}",
+            bytes[0]
+        );
+    }
+
+    #[test]
+    fn request_round_trips_as_named_msgpack() {
+        let request = CaptureRequest {
+            destination_dir: "C:\\Users\\someone\\Desktop".to_owned(),
+            host_environment: vec![CaptureEnvEntry {
+                key: "musicbee_build".to_owned(),
+                value: "3.6.8859".to_owned(),
+            }],
+        };
+        let bytes = rmp_serde::to_vec_named(&request).expect("request serializes");
+        let back: CaptureRequest = rmp_serde::from_slice(&bytes).expect("named map decodes");
+        assert_eq!(back.destination_dir, request.destination_dir);
+        assert_eq!(back.host_environment[0].key, "musicbee_build");
+        assert_eq!(back.host_environment[0].value, "3.6.8859");
+    }
+
+    #[test]
+    fn a_capture_raises_the_level_but_never_lowers_it() {
+        // Trace is more than debug; a capture must not take it away.
+        assert_eq!(
+            directive_for(LogLevel::Trace),
+            "info,mbrc_core=trace,mbrc=trace"
+        );
+        assert_eq!(
+            directive_for(LogLevel::Debug),
+            "info,mbrc_core=debug,mbrc=debug"
+        );
+        assert_eq!(directive_for(LogLevel::Info), "mbrc_core=info,info");
+    }
+
+    #[test]
+    fn expiring_a_stale_generation_leaves_a_newer_capture_alone() {
+        let _exclusive = exclusive();
+        reset();
+        let mut guard = lock();
+        guard.session = Some(Session {
+            generation: 42,
+            started_unix_ms: now_unix_ms(),
+            started: Instant::now(),
+            log_offset: 0,
+            host_environment: Vec::new(),
+        });
+        drop(guard);
+
+        // A watchdog from an earlier capture waking up late.
+        expire(41);
+        assert_eq!(status().state, CAPTURE_CAPTURING);
+
+        reset();
+    }
+
+    #[test]
+    fn the_persisted_record_round_trips() {
+        let dir = std::env::temp_dir().join("mbrc-capture-persist");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let storage = dir.to_str().expect("utf8 dir");
+
+        let session = Session {
+            generation: 1,
+            started_unix_ms: 1_700_000_000_000,
+            started: Instant::now(),
+            log_offset: 4096,
+            host_environment: vec![CaptureEnvEntry {
+                key: "os".to_owned(),
+                value: "Windows 11".to_owned(),
+            }],
+        };
+        persist(storage, &session);
+
+        let back = read_persisted(storage).expect("record reads back");
+        assert_eq!(back.started_unix_ms, 1_700_000_000_000);
+        assert_eq!(back.log_offset, 4096);
+        assert_eq!(back.host_environment[0].value, "Windows 11");
+
+        clear_persisted(storage);
+        assert!(read_persisted(storage).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Drive a whole capture against a real `Core` on a scratch storage dir:
+    /// start, log something, stop, and read the bundle back. The one test that
+    /// proves the pieces fit together rather than testing each in isolation.
+    #[test]
+    fn a_capture_start_to_bundle_produces_a_readable_zip() {
+        let _exclusive = exclusive();
+        use crate::config::Config;
+        use crate::providers::NullProviders;
+        use std::sync::Arc;
+
+        reset();
+        let dir = std::env::temp_dir().join("mbrc-capture-endtoend");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let storage = dir.to_str().expect("utf8 dir").to_owned();
+
+        // Seed a log with a line from *before* the capture, so the window has
+        // something to exclude.
+        std::fs::write(
+            crate::logging::active_log_path(&storage),
+            "before the capture\n",
+        )
+        .expect("seed log");
+
+        let config = Config {
+            storage_path: storage.clone(),
+            // Loopback: a test must never bind 0.0.0.0 (Windows Firewall prompts
+            // per binary path, and cargo re-hashes those every rebuild).
+            ..Config::for_test(0)
+        };
+        let core = Arc::new(Core::new(Arc::new(NullProviders), config));
+
+        let environment = vec![CaptureEnvEntry {
+            key: "musicbee_build".to_owned(),
+            value: "3.6.8859".to_owned(),
+        }];
+        assert_eq!(
+            start(
+                &core,
+                CaptureRequest {
+                    destination_dir: String::new(),
+                    host_environment: environment,
+                }
+            ),
+            MbrcResult::Ok,
+            "a capture should start on an idle core"
+        );
+        assert_eq!(status().state, CAPTURE_CAPTURING);
+        // A second start while one runs is refused, not queued.
+        assert_eq!(
+            start(&core, CaptureRequest::default()),
+            MbrcResult::AlreadyRunning
+        );
+
+        let started = status().started_unix_ms;
+        let offset = "before the capture
+"
+        .len() as u64;
+
+        // Something happening during the window.
+        {
+            use std::io::Write as _;
+            let mut log = std::fs::OpenOptions::new()
+                .append(true)
+                .open(crate::logging::active_log_path(&storage))
+                .expect("append to log");
+            writeln!(log, "during the capture").expect("write log line");
+        }
+
+        let out = dir.join("desktop");
+        // Stop carries only the destination; the environment was recorded at
+        // start, which is what the host does.
+        let request = CaptureRequest {
+            destination_dir: out.to_str().expect("utf8 dir").to_owned(),
+            host_environment: Vec::new(),
+        };
+        assert_eq!(stop(core.clone(), &request), MbrcResult::Ok);
+
+        // `stop` hands the build to a thread that first checks the core is still
+        // initialized - which a directly-constructed `Core` never is, so the
+        // thread returns without building. Drive the work half here; the guard
+        // itself is covered by `a_bundle_is_skipped_when_the_core_shut_down`.
+        let session = Session {
+            generation: 0,
+            started_unix_ms: started,
+            started: Instant::now(),
+            log_offset: offset,
+            host_environment: vec![CaptureEnvEntry {
+                key: "musicbee_build".to_owned(),
+                value: "3.6.8859".to_owned(),
+            }],
+        };
+        finish(&core, &session, &request.destination_dir);
+
+        let settled = status();
+        assert_eq!(
+            settled.state, CAPTURE_DONE,
+            "bundle did not finish: {}",
+            settled.message
+        );
+
+        let file = std::fs::File::open(&settled.bundle_path).expect("bundle exists");
+        let mut archive = zip::ZipArchive::new(file).expect("bundle is a zip");
+        let mut window = String::new();
+        {
+            use std::io::Read as _;
+            archive
+                .by_name("capture.log")
+                .expect("capture.log present")
+                .read_to_string(&mut window)
+                .expect("read capture.log");
+        }
+        assert_eq!(
+            window, "during the capture\n",
+            "the window should exclude what was logged before the capture"
+        );
+
+        let mut body = String::new();
+        {
+            use std::io::Read as _;
+            archive
+                .by_name("report.json")
+                .expect("report.json present")
+                .read_to_string(&mut body)
+                .expect("read report.json");
+        }
+        let report: serde_json::Value = serde_json::from_str(&body).expect("report parses");
+        assert_eq!(
+            report["capture"]["host_environment"]["musicbee_build"],
+            "3.6.8859"
+        );
+        assert_eq!(report["listening"]["port"], 0);
+        // The redaction policy travelled with the report.
+        assert_eq!(
+            report["settings"]["redacted_keys"],
+            serde_json::json!(["allowed_addresses"])
+        );
+
+        reset();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_bundle_is_skipped_when_the_core_shut_down() {
+        let _exclusive = exclusive();
+        // The C# callback delegates are released at `mbrc_shutdown`, and the
+        // report reads the plugin version back through them. A test `Core` is
+        // never registered in the global state, so this is the shut-down case.
+        use crate::config::Config;
+        use crate::providers::NullProviders;
+        use std::sync::Arc;
+
+        reset();
+        assert!(
+            !crate::state::is_initialized(),
+            "this test needs an uninitialized global core"
+        );
+
+        let dir = std::env::temp_dir().join("mbrc-capture-shutdown");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let storage = dir.to_str().expect("utf8 dir").to_owned();
+        let config = Config {
+            storage_path: storage,
+            ..Config::for_test(0)
+        };
+        let core = Arc::new(Core::new(Arc::new(NullProviders), config));
+
+        assert_eq!(start(&core, CaptureRequest::default()), MbrcResult::Ok);
+        let out = dir.join("desktop");
+        let request = CaptureRequest {
+            destination_dir: out.to_str().expect("utf8 dir").to_owned(),
+            host_environment: Vec::new(),
+        };
+        assert_eq!(stop(core.clone(), &request), MbrcResult::Ok);
+
+        // The thread should bail out rather than write anything.
+        let mut settled = status();
+        for _ in 0..100 {
+            if settled.state != CAPTURE_WRITING {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+            settled = status();
+        }
+        assert_eq!(settled.state, CAPTURE_IDLE);
+        assert!(
+            !out.exists(),
+            "nothing should have been written after a shutdown"
+        );
+
+        reset();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resuming_does_not_replay_over_a_live_capture() {
+        let _exclusive = exclusive();
+        // A settings save that changes the port re-inits the core in-process, so
+        // resume runs again while a capture is genuinely still going.
+        use crate::config::Config;
+        use crate::providers::NullProviders;
+        use std::sync::Arc;
+
+        reset();
+        let dir = std::env::temp_dir().join("mbrc-capture-reinit");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let storage = dir.to_str().expect("utf8 dir").to_owned();
+
+        let config = Config {
+            storage_path: storage.clone(),
+            ..Config::for_test(0)
+        };
+        let core = Arc::new(Core::new(Arc::new(NullProviders), config));
+
+        assert_eq!(start(&core, CaptureRequest::default()), MbrcResult::Ok);
+        let started = status().started_unix_ms;
+        let generation_before = GENERATION.load(Ordering::Acquire);
+
+        // The re-init path. The persisted record is still on disk.
+        resume_after_restart(&core);
+
+        assert_eq!(
+            GENERATION.load(Ordering::Acquire),
+            generation_before,
+            "resume must not bump the generation over a live capture (a second watchdog)"
+        );
+        let after = status();
+        assert_eq!(after.state, CAPTURE_CAPTURING);
+        assert_eq!(
+            after.started_unix_ms, started,
+            "the live capture's start must survive a re-init"
+        );
+
+        cancel(&core);
+        reset();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn an_unreadable_record_is_discarded_not_fatal() {
+        let dir = std::env::temp_dir().join("mbrc-capture-garbage");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let storage = dir.to_str().expect("utf8 dir");
+        std::fs::write(capture_file(storage), "{ not json").expect("seed garbage");
+
+        assert!(read_persisted(storage).is_none());
+        // And it cleans up after itself, so the next start is not haunted by it.
+        assert!(!capture_file(storage).exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/packages/mbrc-core/src/diagnostics/mod.rs
+++ b/packages/mbrc-core/src/diagnostics/mod.rs
@@ -1,0 +1,21 @@
+//! Diagnostics capture: the supported way for a user to report a bug.
+//!
+//! A user presses Start in the Configure panel, reproduces the problem, presses
+//! Stop, and gets one zip they can attach to an issue. Before this, a useful
+//! report meant knowing that logs exist, that the default level records no wire
+//! frames, where the storage folder is, and which of half a dozen version
+//! numbers a maintainer would ask for.
+//!
+//! - [`capture`] owns the session (the log-level override and its lifetime).
+//! - [`report`] assembles the environment and core state into `report.json`.
+//! - [`redact`] is the bundle's own redaction policy - secrets out, everything
+//!   else readable.
+//! - [`bundle`] writes the zip.
+//!
+//! Nothing here uploads anything. The bundle lands in a folder the host names,
+//! and what happens to it next is the user's decision.
+
+pub mod bundle;
+pub mod capture;
+pub mod redact;
+pub mod report;

--- a/packages/mbrc-core/src/diagnostics/redact.rs
+++ b/packages/mbrc-core/src/diagnostics/redact.rs
@@ -1,0 +1,149 @@
+//! The diagnostics bundle's redaction policy.
+//!
+//! Deliberately separate from [`crate::logging::redact_frame`]. That one is
+//! built for wire frames: it elides base64 blobs (cover/image/art/lyrics) so the
+//! log stays readable, and does nothing about credentials because a frame has
+//! none. A bundle is different - it carries the user's whole settings file, and
+//! they are about to attach it to a public issue.
+//!
+//! The policy is narrow on purpose: **strip secrets, keep the rest readable.**
+//! Credentials in `proxy_override` are masked and `allowed_addresses` is
+//! dropped; file paths, LAN addresses, hostname and port stay exactly as they
+//! are. Redacting those too would be safer to paste and would also make the
+//! bug classes that most need this (library paths, cover scanning, who is
+//! allowed to connect) undiagnosable from the bundle alone.
+
+use serde_json::{Map, Value};
+
+/// What replaces a masked credential. Keeping the shape visible tells the
+/// maintainer a proxy with auth is configured, which is itself a clue.
+const MASK: &str = "<redacted>";
+
+/// Settings keys dropped from the bundle entirely.
+const DROPPED_KEYS: &[&str] = &["allowed_addresses"];
+
+/// Apply the bundle policy to a serialized [`crate::config::Config`].
+///
+/// Takes and returns JSON rather than a `Config` so the policy lives in one
+/// place regardless of who is serializing: today that is `report.json`'s
+/// `settings` block, the bundle's only copy of the user's settings.
+pub fn settings(mut value: Value) -> Value {
+    let Some(object) = value.as_object_mut() else {
+        return value;
+    };
+    for key in DROPPED_KEYS {
+        object.remove(*key);
+    }
+    if let Some(Value::String(proxy)) = object.get("proxy_override") {
+        let masked = mask_url_credentials(proxy);
+        object.insert("proxy_override".to_owned(), Value::String(masked));
+    }
+    note_dropped(object);
+    value
+}
+
+/// Record what the policy removed, so a reader of the bundle is never left
+/// wondering whether a missing key means "unset" or "withheld".
+fn note_dropped(object: &mut Map<String, Value>) {
+    let dropped: Vec<Value> = DROPPED_KEYS
+        .iter()
+        .map(|k| Value::String((*k).to_owned()))
+        .collect();
+    object.insert("redacted_keys".to_owned(), Value::Array(dropped));
+}
+
+/// Mask the userinfo in a `scheme://user:pass@host:port` URL, leaving the rest
+/// intact. Anything without userinfo is returned untouched, so the common case
+/// (`http://proxy.corp:8080`) stays fully readable.
+///
+/// Deliberately string-level rather than URL-parsed: a value the user typed by
+/// hand may not parse, and a proxy setting that fails to parse must still not
+/// leak its password.
+fn mask_url_credentials(url: &str) -> String {
+    // Userinfo ends at the last '@' before the first '/' of the path, so a path
+    // containing '@' cannot pull the split past the authority.
+    let authority_end = url
+        .find("://")
+        .map(|i| i + 3)
+        .and_then(|start| url[start..].find('/').map(|i| start + i))
+        .unwrap_or(url.len());
+    let Some(at) = url[..authority_end].rfind('@') else {
+        return url.to_owned();
+    };
+    let start = url.find("://").map(|i| i + 3).unwrap_or(0);
+    if at < start {
+        return url.to_owned();
+    }
+    format!("{}{MASK}{}", &url[..start], &url[at..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_json() -> Value {
+        serde_json::json!({
+            "port": 3000,
+            "allowed_addresses": ["192.168.1.50", "192.168.1.51"],
+            "proxy_override": "http://alice:hunter2@proxy.corp:8080",
+            "storage_path": r"C:\Users\someone\AppData\MusicBee\mb_remote",
+        })
+    }
+
+    #[test]
+    fn drops_allowed_addresses_and_says_so() {
+        let out = settings(settings_json());
+        let object = out.as_object().expect("settings stay an object");
+        assert!(!object.contains_key("allowed_addresses"));
+        assert_eq!(
+            object["redacted_keys"],
+            serde_json::json!(["allowed_addresses"])
+        );
+    }
+
+    #[test]
+    fn masks_proxy_credentials_but_keeps_the_host() {
+        let out = settings(settings_json());
+        let proxy = out["proxy_override"]
+            .as_str()
+            .expect("proxy stays a string");
+        assert!(!proxy.contains("hunter2"), "password survived: {proxy}");
+        assert!(!proxy.contains("alice"), "username survived: {proxy}");
+        assert_eq!(proxy, "http://<redacted>@proxy.corp:8080");
+    }
+
+    #[test]
+    fn keeps_paths_and_port_readable() {
+        // The whole point of this policy: a library-path bug must stay
+        // diagnosable from the bundle.
+        let out = settings(settings_json());
+        assert_eq!(out["port"], 3000);
+        assert!(out["storage_path"]
+            .as_str()
+            .expect("path stays a string")
+            .contains("mb_remote"));
+    }
+
+    #[test]
+    fn leaves_a_credential_free_proxy_alone() {
+        assert_eq!(
+            mask_url_credentials("http://proxy.corp:8080"),
+            "http://proxy.corp:8080"
+        );
+        assert_eq!(mask_url_credentials(""), "");
+    }
+
+    #[test]
+    fn an_at_sign_in_the_path_does_not_move_the_split() {
+        // rfind('@') over the whole string would mask the authority away here.
+        assert_eq!(
+            mask_url_credentials("http://proxy.corp:8080/pac@v2.dat"),
+            "http://proxy.corp:8080/pac@v2.dat"
+        );
+    }
+
+    #[test]
+    fn a_non_object_payload_is_returned_unchanged() {
+        assert_eq!(settings(Value::Null), Value::Null);
+    }
+}

--- a/packages/mbrc-core/src/diagnostics/report.rs
+++ b/packages/mbrc-core/src/diagnostics/report.rs
@@ -1,0 +1,116 @@
+//! `report.json`: the environment and core state a bug report needs, assembled
+//! in one place.
+//!
+//! Nothing here is new state - every value already existed for the settings
+//! panel, the update flow, or the caches. The point is that a maintainer
+//! reading an issue should not have to ask for any of it, and a user should not
+//! have to know it exists.
+
+use serde_json::{json, Value};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::diagnostics::redact;
+use crate::ffi::dtos::CaptureEnvEntry;
+use crate::state::Core;
+
+/// Assemble the report for a capture that began at `started_unix_ms`.
+///
+/// Takes `&Core` rather than reaching for the global state so it stays testable
+/// and so the caller keeps control of the lock: this reads a fair amount, and
+/// none of it should happen with the core mutex held.
+pub fn build(core: &Core, host_env: &[CaptureEnvEntry], started_unix_ms: i64) -> Value {
+    json!({
+        "generated_at": now_rfc3339(),
+        "capture": {
+            "started_unix_ms": started_unix_ms,
+            "host_environment": host_environment(host_env),
+        },
+        "versions": versions(core),
+        "settings": settings(core),
+        "listening": listening(core),
+        "caches": caches(core),
+        "blocked_connections": core.blocked.recent(),
+        "update": update(core),
+        "process": {
+            "rss_mib": crate::logging::rss_mib(),
+        },
+    })
+}
+
+/// The report's own timestamp. Empty rather than a fake value if the clock
+/// cannot be formatted - an absent timestamp is honest, a wrong one is not.
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_default()
+}
+
+/// What only the host can see, flattened from the key/value pairs C# sent
+/// (MusicBee build, Windows version, CLR version).
+fn host_environment(entries: &[CaptureEnvEntry]) -> Value {
+    let mut map = serde_json::Map::new();
+    for entry in entries {
+        map.insert(entry.key.clone(), Value::String(entry.value.clone()));
+    }
+    Value::Object(map)
+}
+
+/// Every version that identifies this build. `plugin` comes from the host and
+/// can legitimately be absent (a provider error), which is itself worth seeing.
+fn versions(core: &Core) -> Value {
+    json!({
+        "core": crate::updates::CORE_VERSION,
+        "plugin": core.providers.plugin_version().ok(),
+        "abi": crate::ffi::types::MBRC_ABI_VERSION,
+        "protocol_supported": crate::protocol::version::SUPPORTED_VERSIONS,
+    })
+}
+
+/// The user's settings, through the bundle's redaction policy. A serialization
+/// failure yields null rather than sinking the whole report.
+fn settings(core: &Core) -> Value {
+    serde_json::to_value(&core.config)
+        .map(redact::settings)
+        .unwrap_or(Value::Null)
+}
+
+/// What a client could reach this machine on - the single most common thing a
+/// "the app can't find my PC" report is missing.
+fn listening(core: &Core) -> Value {
+    let addresses: Vec<String> = crate::discovery::usable_ipv4_ifaces()
+        .into_iter()
+        .map(|(ip, _mask)| ip.to_string())
+        .collect();
+    json!({
+        "port": core.config.port,
+        "bind_address": core.config.bind_address,
+        "addresses": addresses,
+        "mdns_enabled": core.config.mdns_enabled,
+    })
+}
+
+/// Cache health, the usual suspect behind "sync never finishes".
+fn caches(core: &Core) -> Value {
+    json!({
+        "tracks_cached": crate::server::commands::library::cached_tracks_count(&core.metadata_cache),
+        "track_index_count": core.metadata_cache.track_count(),
+        "covers_cached": core.cover_store.cached_count(),
+        "metadata_ready": core.metadata_cache.is_validated(),
+        "cover_build_running": core.cover_store.is_building(),
+        "reconciling": core.is_reconciling(),
+        "tracks_synced_at_unix": core.metadata_cache.tracks_synced_at(),
+    })
+}
+
+/// Where the update flow stands, plus the persisted bookkeeping behind it -
+/// which channel the user follows is often the first thing worth knowing about
+/// a beta report.
+fn update(core: &Core) -> Value {
+    let status = crate::updates::service::status(core);
+    json!({
+        "status": status,
+        "channel": core.config.update_channel,
+        "check_enabled": core.config.update_check_enabled,
+        "check_interval_hours": core.config.update_check_interval_hours,
+    })
+}

--- a/packages/mbrc-core/src/ffi/dtos.rs
+++ b/packages/mbrc-core/src/ffi/dtos.rs
@@ -201,3 +201,56 @@ pub struct ListeningInfo {
     /// dropped. Empty when the host has no reachable non-loopback interface.
     pub addresses: Vec<String>,
 }
+
+/// Where the diagnostics capture stands, surfaced to the settings panel's
+/// Diagnostics group (result of the `CaptureStatus` host query). A Rust -> C#
+/// *result*. The state machine that produces it, and the `CAPTURE_*` spellings
+/// `state` carries, live in [`crate::diagnostics::capture`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaptureStatus {
+    /// One of the `CAPTURE_*` constants: `idle`, `capturing`, `writing`,
+    /// `done`, `error`.
+    pub state: String,
+    /// When the running capture began, Unix epoch milliseconds (UTC), or 0 when
+    /// none is running. C# renders it in local time.
+    pub started_unix_ms: i64,
+    /// Seconds left before the safety auto-stop ends a running capture; 0 when
+    /// none is running. The panel counts the user down rather than letting a
+    /// forgotten capture sit at debug level.
+    pub seconds_remaining: i32,
+    /// The last bundle written (full path), so the panel can name the file it
+    /// just produced. Empty until one has been.
+    pub bundle_path: String,
+    /// Why the capture failed. Empty otherwise - a status line that only ever
+    /// carries errors is one the panel can render without interpreting it.
+    pub message: String,
+}
+
+/// What the host passes with a capture command (`StartCapture` / `StopCapture`).
+/// A C# -> Rust *params* payload; both fields are optional in the sense that the
+/// command that does not need one sends it empty.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CaptureRequest {
+    /// Where `StopCapture` writes the zip. The host resolves it (the CLR's
+    /// known-folder lookup handles a redirected Desktop; `%USERPROFILE%\Desktop`
+    /// does not), and the core writes straight to a file there rather than
+    /// handing a multi-megabyte buffer back across the FFI boundary in a 32-bit
+    /// process.
+    #[serde(default)]
+    pub destination_dir: String,
+    /// What only the host can see, recorded verbatim in the report: MusicBee's
+    /// build number, the Windows version, and the CLR version. Free-form
+    /// key/value pairs so adding one never needs an ABI change.
+    #[serde(default)]
+    pub host_environment: Vec<CaptureEnvEntry>,
+}
+
+/// One host-supplied environment fact for the report (see
+/// [`CaptureRequest::host_environment`]).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CaptureEnvEntry {
+    /// The fact's name, e.g. `musicbee_build`.
+    pub key: String,
+    /// Its value, already rendered as text by the host.
+    pub value: String,
+}

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -233,6 +233,10 @@ pub enum HostQueryType {
     /// Updates group. Returns a MessagePack `UpdateStatus`. Always answers, even
     /// before a check has ever run.
     UpdateStatus = 4,
+    /// Where the diagnostics capture stands (idle / capturing / writing / done /
+    /// error), for the panel's Diagnostics group. Returns a MessagePack
+    /// `CaptureStatus`. Always answers, even when nothing has ever been captured.
+    CaptureStatus = 5,
 }
 
 impl HostQueryType {
@@ -242,6 +246,7 @@ impl HostQueryType {
             2 => Some(Self::RecentBlocked),
             3 => Some(Self::ListeningAddresses),
             4 => Some(Self::UpdateStatus),
+            5 => Some(Self::CaptureStatus),
             _ => None,
         }
     }
@@ -275,6 +280,20 @@ pub enum HostCommandType {
     /// Record that the user does not want to be offered the currently available
     /// version again.
     SkipUpdate = 6,
+    /// Begin a diagnostics capture: raise the log level to debug for the
+    /// session only and start a window the bundle will slice out of the log.
+    /// The params are a MessagePack [`crate::ffi::dtos::CaptureRequest`] whose
+    /// `host_environment` carries what the core cannot see (MusicBee build, OS,
+    /// CLR). Rejected while a capture is already running.
+    StartCapture = 7,
+    /// End the capture and write the bundle. The params are a MessagePack
+    /// [`crate::ffi::dtos::CaptureRequest`] whose `destination_dir` says where
+    /// the zip goes - the host resolves it, since a redirected Desktop is
+    /// something only the CLR's known-folder lookup gets right. The resulting
+    /// path lands in [`HostQueryType::CaptureStatus`].
+    StopCapture = 8,
+    /// Abandon the capture: restore the log level and write nothing.
+    CancelCapture = 9,
 }
 
 impl HostCommandType {
@@ -286,6 +305,9 @@ impl HostCommandType {
             4 => Some(Self::CheckForUpdate),
             5 => Some(Self::DownloadUpdate),
             6 => Some(Self::SkipUpdate),
+            7 => Some(Self::StartCapture),
+            8 => Some(Self::StopCapture),
+            9 => Some(Self::CancelCapture),
             _ => None,
         }
     }
@@ -308,6 +330,10 @@ pub enum HostEventType {
     /// panel should re-query [`HostQueryType::UpdateStatus`]. Raised from the
     /// background job's own thread, so the host marshals before touching UI.
     UpdateStatusChanged = 2,
+    /// A diagnostics capture started, finished, failed, or hit its safety
+    /// auto-stop; the panel should re-query [`HostQueryType::CaptureStatus`].
+    /// The auto-stop fires from a timer thread, so the host marshals first.
+    CaptureStatusChanged = 3,
 }
 
 /// Callback table handed from C# to Rust at `mbrc_initialize`.
@@ -406,8 +432,12 @@ mod tests {
             HostQueryType::from_i32(4),
             Some(HostQueryType::UpdateStatus)
         );
+        assert_eq!(
+            HostQueryType::from_i32(5),
+            Some(HostQueryType::CaptureStatus)
+        );
         assert_eq!(HostQueryType::from_i32(0), None);
-        assert_eq!(HostQueryType::from_i32(5), None);
+        assert_eq!(HostQueryType::from_i32(6), None);
         assert_eq!(
             HostCommandType::from_i32(1),
             Some(HostCommandType::RebuildMetadata)
@@ -432,10 +462,23 @@ mod tests {
             HostCommandType::from_i32(6),
             Some(HostCommandType::SkipUpdate)
         );
-        assert_eq!(HostCommandType::from_i32(7), None);
+        assert_eq!(
+            HostCommandType::from_i32(7),
+            Some(HostCommandType::StartCapture)
+        );
+        assert_eq!(
+            HostCommandType::from_i32(8),
+            Some(HostCommandType::StopCapture)
+        );
+        assert_eq!(
+            HostCommandType::from_i32(9),
+            Some(HostCommandType::CancelCapture)
+        );
+        assert_eq!(HostCommandType::from_i32(10), None);
         // HostEventType is core -> host (no from_i32), but its contract value is
         // still pinned so the C# enum stays in sync.
         assert_eq!(HostEventType::CacheStatusChanged as i32, 1);
         assert_eq!(HostEventType::UpdateStatusChanged as i32, 2);
+        assert_eq!(HostEventType::CaptureStatusChanged as i32, 3);
     }
 }

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod config;
 pub mod cover;
+pub mod diagnostics;
 pub mod discovery;
 pub mod ffi;
 pub mod logging;
@@ -95,7 +96,17 @@ pub unsafe extern "C" fn mbrc_initialize(
         let config = config::Config::load(&storage_path);
         let providers: Arc<dyn Providers> =
             Arc::new(FfiProviders::new(SafeCallbacks::new(callbacks)));
-        state::initialize(providers, config) as c_int
+        let result = state::initialize(providers, config);
+        if result == MbrcResult::Ok {
+            // A capture MusicBee restarted through carries on: the log file is
+            // appended rather than truncated, so the window it recorded is still
+            // there, and a bug that only happens at startup is exactly the one
+            // worth capturing.
+            if let Some(core) = state::core_handle() {
+                diagnostics::capture::resume_after_restart(&core);
+            }
+        }
+        result as c_int
     })
 }
 

--- a/packages/mbrc-core/src/logging.rs
+++ b/packages/mbrc-core/src/logging.rs
@@ -106,7 +106,7 @@ impl RotatingWriter {
         if let Some(mut f) = inner.file.take() {
             let _ = f.flush();
         }
-        let gz = |n: u32| self.path.with_file_name(format!("mbrc-core.{n}.log.gz"));
+        let gz = |n: u32| self.path.with_file_name(rolled_log_name(n));
         let _ = std::fs::remove_file(gz(KEEP_GENERATIONS));
         for n in (1..KEEP_GENERATIONS).rev() {
             let _ = std::fs::rename(gz(n), gz(n + 1));
@@ -129,6 +129,37 @@ impl RotatingWriter {
             .ok();
         inner.written = 0;
     }
+}
+
+/// Filename of rolled generation `n`. Shared by the rotation itself and by the
+/// diagnostics bundle, so the two can never disagree about what to look for.
+pub(crate) fn rolled_log_name(n: u32) -> String {
+    format!("mbrc-core.{n}.log.gz")
+}
+
+/// Path of the active core log inside `storage`.
+pub(crate) fn active_log_path(storage: &str) -> PathBuf {
+    Path::new(storage).join(LOG_FILE)
+}
+
+/// Every core log file present in `storage`, newest first: the active file, then
+/// the gzipped generations that still exist. What the diagnostics bundle
+/// collects; missing files are simply absent rather than an error, since a fresh
+/// install has rolled nothing yet.
+pub(crate) fn log_files(storage: &str) -> Vec<PathBuf> {
+    let dir = Path::new(storage);
+    let mut files = Vec::new();
+    let active = dir.join(LOG_FILE);
+    if active.is_file() {
+        files.push(active);
+    }
+    for n in 1..=KEEP_GENERATIONS {
+        let rolled = dir.join(rolled_log_name(n));
+        if rolled.is_file() {
+            files.push(rolled);
+        }
+    }
+    files
 }
 
 /// gzip `src` into `dst` (streamed, so a large rolled file never loads fully).

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -209,6 +209,16 @@ pub fn apply_staged_update() -> Option<crate::ffi::types::UpdateLaunch> {
     Some(crate::updates::elevate::launch(&storage, &current))
 }
 
+/// The initialized core, or `None` before init / after shutdown.
+///
+/// For background work that outlives the call that started it and needs the core
+/// itself rather than just a yes/no - the capture watchdog restoring the log
+/// level, for instance. Cloning the `Arc` out under the lock keeps the caller
+/// from holding the global mutex while it works.
+pub fn core_handle() -> Option<Arc<Core>> {
+    lock().as_ref().map(|state| state.core.clone())
+}
+
 /// Whether a core is currently initialized.
 ///
 /// For background work that outlives the call that started it: the C# callback
@@ -275,12 +285,15 @@ pub fn host_query(kind: HostQueryType, _params: &[u8]) -> Option<Vec<u8>> {
         HostQueryType::RecentBlocked => recent_blocked_bytes(),
         HostQueryType::ListeningAddresses => listening_info_bytes(),
         HostQueryType::UpdateStatus => update_status_bytes(),
+        // Answers without the core, so a panel opened before init still renders
+        // a Diagnostics group instead of a blank one.
+        HostQueryType::CaptureStatus => crate::diagnostics::capture::status_bytes(),
     }
 }
 
 /// Dispatch a host -> core command (fire-and-forget). The generic entry point
 /// for the C# host's app-level actions; add a [`HostCommandType`] variant + arm.
-pub fn host_command(kind: HostCommandType, _params: &[u8]) -> MbrcResult {
+pub fn host_command(kind: HostCommandType, params: &[u8]) -> MbrcResult {
     match kind {
         HostCommandType::RebuildMetadata => rebuild(RebuildScope::Metadata),
         HostCommandType::RebuildCovers => rebuild(RebuildScope::Covers),
@@ -294,7 +307,33 @@ pub fn host_command(kind: HostCommandType, _params: &[u8]) -> MbrcResult {
         HostCommandType::SkipUpdate => {
             with_core(|core| crate::updates::service::skip_available(&core))
         }
+        HostCommandType::StartCapture => match capture_request(params) {
+            Ok(request) => with_core(|core| crate::diagnostics::capture::start(&core, request)),
+            Err(error) => {
+                tracing::warn!(error = %error, "ignoring a malformed capture request");
+                MbrcResult::InvalidArgument
+            }
+        },
+        HostCommandType::StopCapture => match capture_request(params) {
+            Ok(request) => with_core(|core| crate::diagnostics::capture::stop(core, &request)),
+            Err(error) => {
+                tracing::warn!(error = %error, "ignoring a malformed capture request");
+                MbrcResult::InvalidArgument
+            }
+        },
+        HostCommandType::CancelCapture => {
+            with_core(|core| crate::diagnostics::capture::cancel(&core))
+        }
     }
+}
+
+/// Decode a capture command's params. An empty payload is a valid request with
+/// nothing in it (`CancelCapture` sends one), so it is not an error.
+fn capture_request(params: &[u8]) -> Result<crate::ffi::dtos::CaptureRequest, String> {
+    if params.is_empty() {
+        return Ok(crate::ffi::dtos::CaptureRequest::default());
+    }
+    rmp_serde::from_slice(params).map_err(|e| e.to_string())
 }
 
 /// Run `action` against the initialized core, or report `NotInitialized`. The

--- a/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
@@ -299,4 +299,25 @@ namespace MusicBeePlugin.Ffi
         public List<string> addresses { get; set; }
     }
 
+    public class CaptureStatus
+    {
+        public string state { get; set; }
+        public long started_unix_ms { get; set; }
+        public int seconds_remaining { get; set; }
+        public string bundle_path { get; set; }
+        public string message { get; set; }
+    }
+
+    public class CaptureRequest
+    {
+        public string destination_dir { get; set; }
+        public List<CaptureEnvEntry> host_environment { get; set; }
+    }
+
+    public class CaptureEnvEntry
+    {
+        public string key { get; set; }
+        public string value { get; set; }
+    }
+
 }

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -120,6 +120,7 @@ namespace MusicBeePlugin.Ffi.Generated
         RecentBlocked = 2,
         ListeningAddresses = 3,
         UpdateStatus = 4,
+        CaptureStatus = 5,
     }
 
     public enum HostCommandType
@@ -130,12 +131,16 @@ namespace MusicBeePlugin.Ffi.Generated
         CheckForUpdate = 4,
         DownloadUpdate = 5,
         SkipUpdate = 6,
+        StartCapture = 7,
+        StopCapture = 8,
+        CancelCapture = 9,
     }
 
     public enum HostEventType
     {
         CacheStatusChanged = 1,
         UpdateStatusChanged = 2,
+        CaptureStatusChanged = 3,
     }
 
 }

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -445,6 +445,46 @@ namespace MusicBeePlugin.Ffi
         public bool SkipUpdate() => Command(HostCommandType.SkipUpdate);
 
         /// <summary>
+        ///     Where the diagnostics capture stands, for the settings panel's
+        ///     Diagnostics group. Answers even before the core is initialized (the
+        ///     capture state is the core's own, not the running core's), so the
+        ///     panel always has something to render.
+        /// </summary>
+        public CaptureStatus ReadCaptureStatus() => Query<CaptureStatus>(HostQueryType.CaptureStatus);
+
+        /// <summary>
+        ///     Begin a diagnostics capture: the core raises its log level for the
+        ///     session only and starts the window the bundle will be sliced to.
+        ///     <paramref name="environment" /> carries what the core cannot see
+        ///     for itself (MusicBee build, Windows version, CLR version). False if
+        ///     a capture is already running.
+        /// </summary>
+        public bool StartCapture(List<CaptureEnvEntry> environment) =>
+            Command(HostCommandType.StartCapture, Msgpack.Serialize(new CaptureRequest
+            {
+                destination_dir = string.Empty,
+                host_environment = environment ?? new List<CaptureEnvEntry>()
+            }));
+
+        /// <summary>
+        ///     End the capture and write the bundle into
+        ///     <paramref name="destinationDir" />. The host resolves the folder
+        ///     because a redirected Desktop is something only the CLR's known-folder
+        ///     lookup gets right. The write happens in the background; the result
+        ///     arrives as an <see cref="HostEventType.CaptureStatusChanged" /> event
+        ///     with the path in <see cref="CaptureStatus.bundle_path" />.
+        /// </summary>
+        public bool StopCapture(string destinationDir) =>
+            Command(HostCommandType.StopCapture, Msgpack.Serialize(new CaptureRequest
+            {
+                destination_dir = destinationDir ?? string.Empty,
+                host_environment = new List<CaptureEnvEntry>()
+            }));
+
+        /// <summary>Abandon the capture: restore the log level and write nothing.</summary>
+        public bool CancelCapture() => Command(HostCommandType.CancelCapture);
+
+        /// <summary>
         ///     Apply the log level to the core's filter live (no restart needed).
         ///     <paramref name="logLevel"/> is the settings value (<c>info</c> /
         ///     <c>debug</c> / <c>trace</c>), mapped to a tracing filter directive.

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -151,6 +151,27 @@ namespace MusicBeePlugin.Host
         public IntPtr MusicBeeWindow => _api.MB_GetWindowHandle();
 
         /// <summary>
+        ///     MusicBee's plugin-API revision, for the diagnostics report. The
+        ///     core cannot see it - it only ever talks to this shim.
+        /// </summary>
+        public short ApiRevision => _api.ApiRevision;
+
+        /// <summary>Where the diagnostics capture stands, for the panel.</summary>
+        public CaptureStatus ReadCaptureStatus() => _bridge.ReadCaptureStatus();
+
+        /// <summary>
+        ///     Begin a diagnostics capture. <paramref name="environment" /> is the
+        ///     host-only half of the report (MusicBee build, Windows, CLR).
+        /// </summary>
+        public bool StartCapture(List<CaptureEnvEntry> environment) => _bridge.StartCapture(environment);
+
+        /// <summary>End the capture and write the bundle into <paramref name="destinationDir" />.</summary>
+        public bool StopCapture(string destinationDir) => _bridge.StopCapture(destinationDir);
+
+        /// <summary>Abandon the capture without writing a bundle.</summary>
+        public bool CancelCapture() => _bridge.CancelCapture();
+
+        /// <summary>
         ///     Core -> host push events (raised on a background thread). The
         ///     settings panel subscribes to refresh its cache line when a rebuild
         ///     starts/finishes. Forwarded from the native bridge.

--- a/packages/plugin/Settings/CaptureStates.cs
+++ b/packages/plugin/Settings/CaptureStates.cs
@@ -1,0 +1,31 @@
+﻿namespace MusicBeePlugin.Settings
+{
+    /// <summary>
+    ///     The states <see cref="Ffi.CaptureStatus.state" /> can carry, mirroring
+    ///     the <c>CAPTURE_*</c> constants in the core's
+    ///     <c>diagnostics::capture</c>. Strings rather than a generated enum for
+    ///     the same reason as <see cref="UpdateStates" />: the core owns the state
+    ///     machine, and a value this side does not recognise must render as
+    ///     "nothing is running" rather than fail to deserialize.
+    /// </summary>
+    internal static class CaptureStates
+    {
+        /// <summary>Nothing is being captured and nothing has been.</summary>
+        public const string Idle = "idle";
+
+        /// <summary>A capture is running; the core's log is at debug level.</summary>
+        public const string Capturing = "capturing";
+
+        /// <summary>The capture ended and the bundle is being written.</summary>
+        public const string Writing = "writing";
+
+        /// <summary>A bundle was written; <c>bundle_path</c> names it.</summary>
+        public const string Done = "done";
+
+        /// <summary>The safety auto-stop ended a capture nobody stopped.</summary>
+        public const string Expired = "expired";
+
+        /// <summary>The capture or the bundle failed; <c>message</c> says how.</summary>
+        public const string Error = "error";
+    }
+}

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using MusicBeePlugin.Ffi;
 using MusicBeePlugin.Ffi.Generated;
 using MusicBeePlugin.Host;
 
@@ -49,11 +50,13 @@ namespace MusicBeePlugin.Settings
         private const string HelpUrl = "https://mbrc.kelsos.net/help/plugin/";
 
         // The dialog's fixed width, and the height it wants when the screen has
-        // room. Six groups plus the footer do not fit a 720p screen (or a 1080p
+        // room. Seven groups plus the footer do not fit a 720p screen (or a 1080p
         // one at 150% scaling, which is the same thing in logical pixels), so the
-        // height is what actually gets clamped - see PreferredDialogHeight.
+        // height is what actually gets clamped - see PreferredDialogHeight. The
+        // full-height value is what a 1080p screen can give once the taskbar and
+        // chrome are taken off; anything shorter scrolls.
         private const int DialogWidth = 560;
-        private const int DialogHeight = 780;
+        private const int DialogHeight = 860;
 
         // Usable width of a group's value column: the dialog's client width less
         // the 140px label column and the layout's padding. Wrapping labels are
@@ -97,6 +100,12 @@ namespace MusicBeePlugin.Settings
         private Button _updateSkip;
         private LinkLabel _releaseNotes;
         private CheckBox _autoCheck;
+        private Label _captureStatus;
+        private Button _captureStart;
+        private Button _captureStop;
+        private Button _captureCancel;
+        private string _captureState = CaptureStates.Idle;
+        private string _bundlePath = string.Empty;
         private string _updateState = UpdateStates.Unknown;
         private string _notesUrl = string.Empty;
 
@@ -126,6 +135,7 @@ namespace MusicBeePlugin.Settings
             LoadCacheStatus();
             LoadBlockedCount();
             LoadUpdateStatus();
+            LoadCaptureStatus();
             RunConnectionTest();
 
             // The core pushes CacheStatusChanged when a rebuild starts or
@@ -133,11 +143,17 @@ namespace MusicBeePlugin.Settings
             // refresh those lines live while this dialog is open.
             _host.CoreEvent += OnCoreEvent;
 
-            // The blocked-connections log has no push event (it is polled), so keep
-            // the count button current while this panel is open: a device blocked
-            // during troubleshooting bumps the number without reopening.
+            // Two things need polling rather than an event. The blocked-connections
+            // log has no push event at all, so a device blocked during
+            // troubleshooting bumps the count without reopening the panel. And a
+            // running capture's countdown ticks on its own - the core only raises
+            // an event when the capture *changes* state, not once a second.
             _blockedTimer = new System.Windows.Forms.Timer { Interval = 3000 };
-            _blockedTimer.Tick += (s, e) => LoadBlockedCount();
+            _blockedTimer.Tick += (s, e) =>
+            {
+                LoadBlockedCount();
+                if (_captureState == CaptureStates.Capturing) LoadCaptureStatus();
+            };
             _blockedTimer.Start();
         }
 
@@ -203,6 +219,7 @@ namespace MusicBeePlugin.Settings
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // advanced
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // cache
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // updates
+            root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // diagnostics
 
             // No title label: the window title bar already reads "MusicBee Remote";
             // the version sits bottom-left in the button row instead.
@@ -212,6 +229,7 @@ namespace MusicBeePlugin.Settings
             root.Controls.Add(BuildAdvancedGroup());
             root.Controls.Add(BuildCacheGroup());
             root.Controls.Add(BuildUpdatesGroup());
+            root.Controls.Add(BuildDiagnosticsGroup());
             // No trailing spacer row: a Percent-100 row would absorb every
             // overflow and the scroller below would never see one.
 
@@ -515,6 +533,64 @@ namespace MusicBeePlugin.Settings
             return WrapGroup("Updates", layout);
         }
 
+        // The Diagnostics group: Start capture -> reproduce the problem -> Stop
+        // capture, which leaves one zip on the Desktop to attach to an issue.
+        // Structurally the Cache group with a countdown: a wrapping grey status
+        // line over a row of buttons.
+        private Control BuildDiagnosticsGroup()
+        {
+            _captureStatus = new Label
+            {
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                Padding = new Padding(0, 6, 0, 0),
+                ForeColor = SystemColors.GrayText,
+                MaximumSize = new Size(StatusWidth, 0),
+            };
+            _captureStart = new Button
+            {
+                Text = "Start capture",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0, 0, 8, 0),
+            };
+            _captureStart.Click += (s, e) => StartCapture();
+            _captureStop = new Button
+            {
+                Text = "Stop and save",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0, 0, 8, 0),
+            };
+            _captureStop.Click += (s, e) => StopCapture();
+            _captureCancel = new Button
+            {
+                Text = "Cancel",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0),
+            };
+            _captureCancel.Click += (s, e) => CancelCapture();
+
+            var buttons = new FlowLayoutPanel
+            {
+                FlowDirection = FlowDirection.LeftToRight,
+                WrapContents = false,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Anchor = AnchorStyles.Left,
+                Margin = new Padding(0),
+            };
+            buttons.Controls.Add(_captureStart);
+            buttons.Controls.Add(_captureStop);
+            buttons.Controls.Add(_captureCancel);
+
+            var layout = GroupLayout();
+            AddRow(layout, "Status", _captureStatus);
+            AddRow(layout, string.Empty, buttons);
+            return WrapGroup("Diagnostics", layout);
+        }
+
         private Control BuildButtonRow()
         {
             // Bottom-left: the version (the title bar already names the plugin), a
@@ -624,6 +700,204 @@ namespace MusicBeePlugin.Settings
         }
 
         /// <summary>Open the log folder (mbrc-core.log + bootstrap) in Explorer.</summary>
+        // Render whatever the core says the capture is doing. The single source
+        // of truth is the core's status - this method never infers state from
+        // which button was pressed, so a capture started before this dialog was
+        // opened (or resumed across a MusicBee restart) renders correctly.
+        private void LoadCaptureStatus()
+        {
+            var status = _host.ReadCaptureStatus();
+            var previous = _captureState;
+            _captureState = status?.state ?? CaptureStates.Idle;
+            _bundlePath = status?.bundle_path ?? string.Empty;
+
+            var capturing = _captureState == CaptureStates.Capturing;
+            var writing = _captureState == CaptureStates.Writing;
+            _captureStart.Enabled = !capturing && !writing;
+            _captureStop.Enabled = capturing;
+            _captureCancel.Enabled = capturing;
+            _captureStatus.Text = DescribeCapture(status);
+            _captureStatus.ForeColor = _captureState == CaptureStates.Error
+                ? Color.Firebrick
+                : SystemColors.GrayText;
+
+            // Only on the Writing -> Done transition, which is a bundle that
+            // finished while this dialog was watching. Testing "was not Done"
+            // instead would fire on the first read of every dialog opened later
+            // in the session: the core's state stays Done, but a fresh dialog's
+            // field starts at Idle, so reopening Configure would pop an Explorer
+            // window at the old bundle every time.
+            if (previous == CaptureStates.Writing && _captureState == CaptureStates.Done) RevealBundle();
+        }
+
+        private string DescribeCapture(CaptureStatus status)
+        {
+            if (status == null)
+                return "Diagnostics are unavailable - the core is not running.";
+
+            switch (status.state)
+            {
+                case CaptureStates.Capturing:
+                    var minutes = Math.Max(1, status.seconds_remaining / 60);
+                    return "Capturing since " + FormatUnixMs(status.started_unix_ms)
+                        + ". Reproduce the problem, then press Stop and save. Stops on its own in "
+                        + minutes.ToString(CultureInfo.InvariantCulture) + " min.";
+                case CaptureStates.Writing:
+                    return "Writing the diagnostics file...";
+                case CaptureStates.Done:
+                    // Named from the path the core actually wrote, not from where
+                    // it was asked to: StopCapture falls back to the log folder
+                    // when there is no Desktop to resolve, and pointing the user
+                    // at the wrong folder is worse than naming a longer one.
+                    return "Saved " + Path.GetFileName(status.bundle_path)
+                        + " to " + DescribeFolder(status.bundle_path)
+                        + ". Attach it to a bug report.";
+                case CaptureStates.Expired:
+                case CaptureStates.Error:
+                    return status.message;
+                default:
+                    return "Start a capture, reproduce the problem, then stop it: the plugin saves one "
+                        + "file to your Desktop with the detail a bug report needs.";
+            }
+        }
+
+        // "your Desktop" when that is where it went, otherwise the folder name.
+        private static string DescribeFolder(string bundlePath)
+        {
+            try
+            {
+                var folder = Path.GetDirectoryName(bundlePath);
+                if (string.IsNullOrEmpty(folder)) return "your Desktop";
+                var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+                return string.Equals(folder.TrimEnd('\\'), (desktop ?? string.Empty).TrimEnd('\\'),
+                    StringComparison.OrdinalIgnoreCase)
+                    ? "your Desktop"
+                    : folder;
+            }
+            catch (ArgumentException)
+            {
+                return "your Desktop";
+            }
+        }
+
+        // Local time; the core records UTC epoch milliseconds.
+        private static string FormatUnixMs(long unixMs)
+        {
+            if (unixMs <= 0) return "an unknown time";
+            try
+            {
+                return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                    .AddMilliseconds(unixMs)
+                    .ToLocalTime()
+                    .ToString("t", CultureInfo.CurrentCulture);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return "an unknown time";
+            }
+        }
+
+        // The consent point. A capture raises the log level and the file it
+        // produces carries the user's folder paths and LAN addresses, so say so
+        // before either happens rather than in a doc they will not read.
+        private void StartCapture()
+        {
+            var confirm = MessageBox.Show(
+                this,
+                "While a capture runs the plugin logs in more detail, then saves one file to your "
+                + "Desktop when you stop it.\r\n\r\nThat file contains your settings, your music "
+                + "folder paths and this PC's local network addresses - not your password for "
+                + "anything. Look inside it before sending it anywhere.\r\n\r\n"
+                + "The capture stops on its own after 30 minutes.",
+                "MusicBee Remote",
+                MessageBoxButtons.OKCancel,
+                MessageBoxIcon.Information);
+            if (confirm != DialogResult.OK) return;
+
+            if (!_host.StartCapture(HostEnvironment()))
+            {
+                // The command channel only reports pass/fail, so "already
+                // running" has to be read back rather than assumed - the same
+                // false covers a core that is not running at all, and telling
+                // someone a capture is in progress while they are trying to
+                // report that the plugin will not start is the wrong answer.
+                var running = _host.ReadCaptureStatus()?.state == CaptureStates.Capturing;
+                SetStatus(running
+                    ? "A capture is already running."
+                    : "Could not start a capture - see mbrc-core.log.", false);
+                LoadCaptureStatus();
+                return;
+            }
+            LoadCaptureStatus();
+        }
+
+        // The bundle lands on the Desktop. Resolved here rather than in the core
+        // because a OneDrive-redirected Desktop is something only the CLR's
+        // known-folder lookup gets right; %USERPROFILE%\Desktop does not.
+        private void StopCapture()
+        {
+            var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+            if (string.IsNullOrEmpty(desktop))
+            {
+                // No Desktop to write to (a locked-down or redirected profile);
+                // the log folder is somewhere we know exists.
+                desktop = _host.LogDirectory;
+            }
+            if (!_host.StopCapture(desktop))
+            {
+                SetStatus("There was no capture to stop.", false);
+            }
+            LoadCaptureStatus();
+        }
+
+        private void CancelCapture()
+        {
+            _host.CancelCapture();
+            LoadCaptureStatus();
+        }
+
+        // What the core cannot see for itself: it only ever talks to this shim,
+        // so MusicBee's own version, Windows and the CLR have to be handed over.
+        private List<CaptureEnvEntry> HostEnvironment()
+        {
+            var entries = new List<CaptureEnvEntry>();
+            Action<string, string> add = (key, value) =>
+                entries.Add(new CaptureEnvEntry { key = key, value = value ?? string.Empty });
+
+            add("plugin_version", _version);
+            add("musicbee_build", MusicBeeBuild().ToString(CultureInfo.InvariantCulture));
+            add("musicbee_api_revision", _host.ApiRevision.ToString(CultureInfo.InvariantCulture));
+            try
+            {
+                add("os", Environment.OSVersion.VersionString);
+                add("os_64bit", Environment.Is64BitOperatingSystem.ToString());
+                add("clr", Environment.Version.ToString());
+            }
+            catch (Exception)
+            {
+                // A report missing a line is still a report worth having.
+            }
+            return entries;
+        }
+
+        // Show the finished bundle rather than just naming it: the user's next
+        // move is to attach it to something, and they have to find it first.
+        private void RevealBundle()
+        {
+            if (string.IsNullOrEmpty(_bundlePath) || !File.Exists(_bundlePath)) return;
+            try
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", "/select,\"" + _bundlePath + "\"")
+                {
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception)
+            {
+                // Explorer refused; the status line still names the file.
+            }
+        }
+
         private void OpenLogFolder()
         {
             try
@@ -1144,6 +1418,9 @@ namespace MusicBeePlugin.Settings
                     break;
                 case HostEventType.UpdateStatusChanged:
                     refresh = LoadUpdateStatus;
+                    break;
+                case HostEventType.CaptureStatusChanged:
+                    refresh = LoadCaptureStatus;
                     break;
                 default:
                     return;


### PR DESCRIPTION
## Why

There is no supported way for a user to report a bug well. Today that means guessing logs exist, noticing the level sits at `info` (which records **no wire frames**, so the interesting part is not in the file), setting it to Debug, reproducing, finding `mbrc-core.log` plus up to three `.gz` generations, zipping them by hand, and separately typing out plugin version, MusicBee version, Windows build, client app and update channel.

Nothing prompts any of it. There were also no issue templates at all, no troubleshooting doc, and the README's "Report Bug" was a bare link to the issue list. So reports arrive as "sync doesn't work", and every one costs at least a round trip of *"please set the log level to Debug and try again"* before it can start. With `v1.5.0-beta.1` out and beta.2 coming, the people about to file are exactly the people this hurts.

## What

A **Diagnostics** group in the Configure panel: **Start capture** → reproduce → **Stop and save**. One `mbrc-diagnostics-<ts>.zip` lands on the Desktop, Explorer opens with it selected, and the new issue template asks for it.

| Entry | Contents |
| --- | --- |
| `report.json` | Versions (plugin, core, MusicBee, Windows, .NET), settings, listening addresses, cache health, blocked connections, update state, RSS |
| `capture.log` | The log for the capture window only |
| `logs/` | Only when the capture overlapped another file (a roll mid-capture, or a restart) |

## Design notes

**The core owns the session.** C# has no transient-setting concept: its only way to change the log level is a `WriteSettings` that persists it, and a level pushed without one is reverted by the next `Reload()` or `PluginHost.Start`. So the core raises the level for the session only, and:

- never *lowers* it - someone already on trace keeps trace;
- stops itself after 30 minutes, so a forgotten capture cannot fill the 10 MiB × 3 budget;
- records the session in `capture.json`, so a capture survives a MusicBee restart. That is what makes a startup-only bug capturable at all.

**The bundle carries the reproduction, not the user's history.** `capture.log` is sliced from the byte offset where the capture began. Other log files travel only if their mtime falls inside the window. A rolled generation from last week predates the problem, was written at the normal level so holds no wire detail, and is the one part of the bundle nobody can review before sending it.

**Redaction is its own policy** (`diagnostics/redact.rs`), separate from `logging::redact_frame` - that one is built for wire frames and knows nothing about credentials. Here: proxy userinfo masked, `allowed_addresses` dropped, and what was removed is listed under `redacted_keys`. Paths, LAN addresses and ports stay readable, deliberately: the bugs that most need a bundle are about paths and who may connect, and stripping those makes it useless for exactly the reports it exists to serve.

**Nothing is uploaded.** No endpoint, no telemetry, no prefilled URL. The file lands on the Desktop behind a consent dialog that says what is in it, and what happens next is the user's decision.

**FFI is additive only** - no new export, per the note in `ffi/types.rs` naming diagnostics as the reason `mbrc_query`/`mbrc_command` exist. `HostQueryType::CaptureStatus = 5`, `HostCommandType::{Start,Stop,Cancel}Capture = 7..9`, `HostEventType::CaptureStatusChanged = 3`. The zip is written straight to a file rather than returned across the boundary, which would hold it twice in a 32-bit process. `zip` is pinned to the exact version and features `mbrc-release` already uses, so **the crate graph is unchanged**.

The destination folder is resolved host-side: a OneDrive-redirected Desktop is something only the CLR's known-folder lookup gets right, and this keeps known-folder COM out of the core.

## Testing

- `cargo test -p mbrc-core --target i686-pc-windows-msvc`: **200 pass**, including an end-to-end case that starts a capture on a real `Core`, appends a log line, builds the bundle and reads the zip back, asserting the window excludes pre-capture lines and that the redaction policy travelled with the report.
- `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt`, `dotnet format --verify-no-changes`: clean. C# suite: 61 pass.
- Live: MusicBee starts with both DLLs, the ABI check passes over the new enum surface, server + discovery + mDNS all come up.

A code review pass caught seven issues, all fixed in this branch. Two were worth the pass on their own:

- **`Instant` underflow panic on reboot.** On Windows `Instant` counts from boot, and the restart a capture resumes through is often a reboot. Subtracting elapsed capture time from a machine up for one minute underflows, and `Sub` panics — inside `mbrc_initialize`, which would report the plugin as failed to start when the core was in fact already up.
- **Bundle thread calling released C# delegates.** The stop thread had no `is_initialized()` guard, unlike every other detached thread in the core. Press Stop, close MusicBee, and the zip (seconds of work) would then call `plugin_version()` and `on_event` through freed delegates.

The rest: Explorer reopening on every Configure reopen, `resume_after_restart` replaying over a live session on a port-change re-init, a hardcoded "to your Desktop" when the fallback wrote elsewhere, "already running" shown for every start failure including a dead core, and a stale doc comment.

Adding those tests also exposed that the capture `STATE` global made the suite flaky under parallel test threads — the same hazard `state.rs` documents about its own global. Serialized behind a test mutex; lib suite run three times, stable.

## Not in scope

Automatic upload or a crash/telemetry endpoint. That means hosting, a privacy policy, a consent flow and a credential shipped to users, for little more than the zip already gets. If panic reports are wanted later, the narrow version is a panic file plus a "report this" offer on next start — still user-initiated.
