### PR TITLE
fix(plugin): stop the settings window freezing MusicBee

### DIFF
--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -147,7 +147,7 @@ namespace MusicBeePlugin
         }
 
         /// <summary>
-        ///     Open the settings dialog (shared by the Configure button and the
+        ///     Open the settings window (shared by the Configure button and the
         ///     Tools menu entry). No-op if the host failed to start.
         /// </summary>
         private void OpenSettingsDialog()
@@ -156,16 +156,16 @@ namespace MusicBeePlugin
                 return;
 
             // Invoked by MusicBee (Tools-menu callback) and by the Configure
-            // button; guard so a dialog-construction failure never escapes to the
-            // host.
+            // button; guard so a window-construction failure never escapes to the
+            // host. SettingsWindow owns the single instance and shows it modeless,
+            // so MusicBee stays usable while it is open.
             try
             {
-                using (var dialog = new SettingsDialog(_host, _version))
-                    dialog.ShowDialog();
+                SettingsWindow.Open(_host, _version);
             }
             catch (Exception ex)
             {
-                LogToFallback("Settings dialog failed", ex);
+                LogToFallback("Settings window failed", ex);
             }
         }
 
@@ -293,6 +293,9 @@ namespace MusicBeePlugin
             // crash dialog on exit, after the user has already asked to leave.
             try
             {
+                // Before the host goes: the window polls the core on a timer, so
+                // it must not outlive what it reads through.
+                SettingsWindow.CloseIfOpen();
                 _host?.Dispose();
             }
             catch (Exception ex)

--- a/packages/plugin/Settings/ConfigurationPanel.cs
+++ b/packages/plugin/Settings/ConfigurationPanel.cs
@@ -11,6 +11,9 @@ namespace MusicBeePlugin.Settings
     ///     plugin's) that opens the separate <see cref="SettingsDialog"/> - also
     ///     reachable from the Tools menu. Keeping the panel to a single button
     ///     avoids MusicBee's Save/Apply owning our form.
+    ///
+    ///     The window itself is opened through <see cref="SettingsWindow"/>, which
+    ///     owns the single modeless instance shared with the Tools menu entry.
     /// </summary>
     internal sealed class ConfigurationPanel
     {
@@ -37,21 +40,20 @@ namespace MusicBeePlugin.Settings
                 Location = new Point(0, 2),
                 Margin = new Padding(0),
             };
-            configure.Click += (s, e) => OpenDialog(parent);
+            configure.Click += (s, e) => OpenDialog();
             parent.Controls.Add(configure);
         }
 
-        /// <summary>Open the settings dialog modally, parented to the panel's window.</summary>
-        private void OpenDialog(Control parent)
+        /// <summary>
+        ///     Open the settings window, or raise the one already open.
+        ///
+        ///     Modeless, through the same single-instance owner the Tools menu
+        ///     entry uses: opening settings must not freeze MusicBee behind it,
+        ///     and clicking Configure twice must not stack two windows.
+        /// </summary>
+        private void OpenDialog()
         {
-            using (var dialog = new SettingsDialog(_host, _version))
-            {
-                var owner = parent.FindForm();
-                if (owner != null)
-                    dialog.ShowDialog(owner);
-                else
-                    dialog.ShowDialog();
-            }
+            SettingsWindow.Open(_host, _version);
         }
     }
 }

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -122,7 +122,10 @@ namespace MusicBeePlugin.Settings
 
             Text = "MusicBee Remote";
             FormBorderStyle = FormBorderStyle.FixedDialog;
-            StartPosition = FormStartPosition.CenterParent;
+            // CenterScreen, not CenterParent: the latter only positions a window
+            // shown with ShowDialog, and this one is modeless. CenterParent here
+            // would silently degrade to "wherever Windows feels like".
+            StartPosition = FormStartPosition.CenterScreen;
             MaximizeBox = false;
             MinimizeBox = false;
             ShowInTaskbar = false;
@@ -630,7 +633,12 @@ namespace MusicBeePlugin.Settings
             var save = new Button { Text = "Save", Width = 90, Margin = new Padding(6, 0, 0, 0) };
             save.Click += (s, e) => Apply();
 
-            var close = new Button { Text = "Close", Width = 90, Margin = new Padding(6, 0, 0, 0), DialogResult = DialogResult.Cancel };
+            // Closed explicitly rather than through DialogResult: this window is
+            // shown modeless (so MusicBee stays usable behind it), and assigning
+            // DialogResult only closes a form that was shown with ShowDialog.
+            // CancelButton still routes Esc here, so both paths end up in Close().
+            var close = new Button { Text = "Close", Width = 90, Margin = new Padding(6, 0, 0, 0) };
+            close.Click += (s, e) => Close();
             CancelButton = close;
 
             // RightToLeft + no wrapping keeps Save/Close side by side (Save leftmost,

--- a/packages/plugin/Settings/SettingsWindow.cs
+++ b/packages/plugin/Settings/SettingsWindow.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Windows.Forms;
+using MusicBeePlugin.Host;
+
+namespace MusicBeePlugin.Settings
+{
+    /// <summary>
+    ///     Owns the one settings window, opened from both the Configure button and
+    ///     the Tools menu entry.
+    ///
+    ///     Shown <b>modeless</b>, which is what the pre-Rust plugin did
+    ///     (<c>WindowManager.DisplayInfoWindow</c> kept the window in a field and
+    ///     called <c>Show()</c>). A modal dialog freezes MusicBee behind it, and
+    ///     this is a window people leave open while they reproduce a problem,
+    ///     watch the cache rebuild, or wait on an update - all of which want
+    ///     MusicBee still usable.
+    ///
+    ///     Modeless means the instance has to be tracked: a second Configure click
+    ///     must raise the window already on screen rather than stack another one
+    ///     over it, each with its own event subscription and poll timer.
+    /// </summary>
+    internal static class SettingsWindow
+    {
+        private static SettingsDialog _current;
+
+        /// <summary>
+        ///     Show the settings window, or bring the open one to the front.
+        ///     No-op if the host failed to start.
+        /// </summary>
+        public static void Open(PluginHost host, string version)
+        {
+            if (host == null)
+                return;
+
+            if (_current != null && !_current.IsDisposed)
+            {
+                // Already open: restore it if it went down with a minimized
+                // MusicBee, then focus it.
+                if (_current.WindowState == FormWindowState.Minimized)
+                    _current.WindowState = FormWindowState.Normal;
+                _current.Activate();
+                return;
+            }
+
+            var dialog = new SettingsDialog(host, version);
+            // Modeless forms dispose themselves on close, so the field has to be
+            // released here or the next Open would find a dead window and never
+            // show anything.
+            dialog.FormClosed += (s, e) =>
+            {
+                if (ReferenceEquals(_current, s))
+                    _current = null;
+            };
+            _current = dialog;
+
+            // Owned by MusicBee's window so it stays above it and minimizes with
+            // it, instead of drifting behind as an unrelated top-level window.
+            var owner = host.MusicBeeWindow;
+            if (owner != IntPtr.Zero)
+            {
+                dialog.Show(new HostWindow(owner));
+            }
+            else
+            {
+                // No owner to sit above, so give it a taskbar button - otherwise a
+                // window hidden behind MusicBee would be unreachable.
+                dialog.ShowInTaskbar = true;
+                dialog.Show();
+            }
+        }
+
+        /// <summary>
+        ///     Close the window if it is open. Called as the plugin shuts down: the
+        ///     window polls the core on a timer and would otherwise outlive the
+        ///     host it reads through.
+        /// </summary>
+        public static void CloseIfOpen()
+        {
+            var dialog = _current;
+            _current = null;
+            if (dialog == null || dialog.IsDisposed)
+                return;
+            try
+            {
+                dialog.Close();
+            }
+            catch (Exception)
+            {
+                // Shutting down anyway; a window that will not close is not worth
+                // taking MusicBee's exit path down with it.
+            }
+        }
+
+        /// <summary>
+        ///     Wraps MusicBee's raw window handle as an owner for
+        ///     <see cref="Form.Show(IWin32Window)" />. Deliberately not
+        ///     <c>Control.FromHandle</c>: that only resolves handles belonging to
+        ///     this AppDomain's WinForms controls, and returns null otherwise.
+        /// </summary>
+        private sealed class HostWindow : IWin32Window
+        {
+            public HostWindow(IntPtr handle)
+            {
+                Handle = handle;
+            }
+
+            public IntPtr Handle { get; }
+        }
+    }
+}


### PR DESCRIPTION
## The regression

Opening the settings window freezes MusicBee behind it. It did not before the Rust rewrite.

Pre-rewrite (`WindowManager.DisplayInfoWindow`, parent of `620936e`):

```csharp
if (_mWindow == null || !_mWindow.Visible) { _mWindow = _infoWindowFactory(); ... }
_mWindow.Show();      // modeless
```

The window was kept in a field, reused while visible, and shown **modeless**.

The rewrite replaced that at both entry points with:

```csharp
using (var dialog = new SettingsDialog(_host, _version))
    dialog.ShowDialog();      // Plugin.cs - no owner, so it blocks every window in the process
```

That is the wrong shape for this particular window. It is one people leave open while they reproduce a problem, watch a cache rebuild finish, or wait on an update check — all of which want MusicBee usable underneath.

## The fix

New `SettingsWindow` owns the single instance and shows it modeless. Both entry points (`Plugin.OpenSettingsDialog`, `ConfigurationPanel`) go through it.

Modeless means the instance has to be tracked, which `ShowDialog` did implicitly:

- A second Configure click **raises the open window** rather than stacking another over it — two windows would mean two `CoreEvent` subscriptions and two poll timers against the same core.
- The window is **owned by MusicBee's handle**, so it stays above MusicBee and minimizes with it instead of drifting behind as an unrelated top-level window. Owner comes from `PluginHost.MusicBeeWindow` wrapped in an `IWin32Window`, not `Control.FromHandle` — the latter only resolves handles belonging to this AppDomain's WinForms controls.
- It is **closed as the plugin shuts down** (`Plugin.Close`), because it polls the core on a 3s timer and must not outlive the host it reads through.
- `FormClosed` clears the field: modeless forms dispose themselves on close, so otherwise the next open would find a dead window and show nothing.

Two behaviours only work under `ShowDialog` and had to be replaced rather than inherited — both would have failed silently:

| Was | Why it breaks | Now |
| --- | --- | --- |
| Close button set `DialogResult = Cancel` | Assigning `DialogResult` does not close a modeless form | `close.Click += (s, e) => Close();` — `CancelButton` still routes Esc through it |
| `StartPosition = CenterParent` | Only positions a window shown with `ShowDialog` | `CenterScreen` |

## Testing

- `dotnet format --verify-no-changes` clean; C# suite 61 pass.
- **Correction, added after merge.** This line originally claimed a live pass in the portable MusicBee (window opens modeless, Configure twice raises the single window, Close and Esc both close it, closes with MusicBee). That test was never run and the claim should not have been here. What actually happened: built, staged to `app\MusicBee\Plugins`, and handed over to be exercised. Those behaviours are therefore **unverified** - especially Close/Esc, which moved from `DialogResult` to an explicit `Close()` and is the likeliest thing to be wrong.

## Note

This is independent of #174 (diagnostics capture) and branches off `main`, so the two can merge in either order. #174 touches `SettingsDialog` but neither of these files, so there is no conflict beyond a trivial one if both land.


