### PR TITLE
fix(ci): stamp the release version the updater actually reads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,13 @@ jobs:
             }
           }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          # Also into the job environment, so EVERY later step builds the same
+          # version - not just the one step that passes /p:Version. `dotnet test`
+          # rebuilds the plugin project it references, and without this it
+          # re-stamped mb_remote.dll with the bare VersionPrefix and the dist copy
+          # shipped that (see Directory.Build.props). Read by the managed build via
+          # Directory.Build.props and by the Rust core via mbrc-buildinfo.
+          echo "MBRC_VERSION=$version" >> $env:GITHUB_ENV
           echo "Building version: $version"
 
       - name: check code formatting
@@ -123,14 +130,11 @@ jobs:
       - name: build with strict analysis
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
-          # The Rust core and helper stamp themselves from this; without it
-          # mbrc-buildinfo falls back to VersionPrefix in Directory.Build.props,
-          # so every prerelease build would call itself the final version - in
-          # its log lines, in the mDNS TXT record, and in the update check's
-          # fallback when the host cannot report its own version. MSBuild drives
-          # the Rust build through the csproj target, so the environment reaches
-          # it from here.
-          MBRC_VERSION: ${{ steps.version.outputs.VERSION }}
+          # MBRC_VERSION is exported to the whole job by the resolve step above,
+          # so it reaches this build, the test step's implicit rebuild, and the
+          # Rust core (mbrc-buildinfo) alike. Without it a prerelease build calls
+          # itself the final version - in its log lines, in the mDNS TXT record,
+          # and in the update check.
         run: |
           echo "🔍 Building with strict static analysis (warnings as errors)..."
           msbuild MBRC.sln /p:Configuration="Release" /p:MSBuildCI="true" /p:Version=$env:VERSION /m /v:M /fl /nr:false
@@ -149,6 +153,27 @@ jobs:
           flags: csharp
           fail_ci_if_error: false
           verbose: true
+
+      # The stamp is what the updater compares, and it being wrong is invisible in
+      # a green build: beta.1 and beta.2 both shipped mis-stamped and nothing
+      # noticed until a tester was never offered an update. Checked after every
+      # step that could have rebuilt the assembly, and immediately before the
+      # bytes are copied for shipping.
+      - name: verify the stamped version
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          $dll = "build/bin/plugin/Release/net48/mb_remote.dll"
+          $stamped = (Get-Item $dll).VersionInfo.ProductVersion
+          # InformationalVersion carries "+<sha>" build metadata; the part before
+          # it is the version the update check actually compares.
+          $core = $stamped.Split('+')[0]
+          echo "stamped: $stamped"
+          if ($core -ne $env:VERSION) {
+            Write-Error "mb_remote.dll is stamped '$core' but this build is '$env:VERSION'. A later step rebuilt it without the version - shipping this would tell every client the wrong version."
+            exit 1
+          }
+          echo "✅ stamped version matches $env:VERSION"
 
       - name: copy to dist
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,25 @@
     <!-- VersionSuffix is set by CI for nightlies (e.g., -nightly.123) -->
     <!-- For releases, CI sets the full Version from the tag -->
 
+    <!--
+      The release version, taken from the environment rather than a command-line
+      property, so that EVERY MSBuild invocation in a CI job agrees on it - not
+      just the one that was passed /p:Version.
+
+      This is not belt-and-braces; it fixes a bug that shipped in 1.5.0-beta.1 and
+      -beta.2. `dotnet test` rebuilds the plugin project it references, without the
+      /p:Version the explicit build was given, so it silently overwrote the
+      correctly-stamped mb_remote.dll with one that fell back to VersionPrefix.
+      The dist copy ran afterwards, so both betas shipped stamped "1.5.0" while
+      their manifests said "1.5.0-beta.N" - and since semver ranks a prerelease
+      below its release, every update check answered "up to date" and no beta user
+      could ever be offered anything, including 1.5.0 final.
+
+      MBRC_VERSION already existed for the Rust core (mbrc-buildinfo reads it);
+      this makes the managed side honour the same single source.
+    -->
+    <Version Condition="'$(MBRC_VERSION)' != ''">$(MBRC_VERSION)</Version>
+
     <!-- Shared assembly information -->
     <Company>Kelsos</Company>
     <Authors>Konstantinos Paparas</Authors>


### PR DESCRIPTION
## The bug

Both published betas shipped `mb_remote.dll` stamped **`1.5.0`**, while their manifests said `1.5.0-beta.1` and `1.5.0-beta.2`:

```
beta.1  InformationalVersion = 1.5.0+42632c9…
beta.2  InformationalVersion = 1.5.0+f246573…
```

`Plugin.ProductVersion` strips the `+sha`, so the plugin reports `1.5.0`. Semver ranks a prerelease **below** its release — `mbrc-release`'s own test asserts it (`a_prerelease_orders_below_its_release`) — so `1.5.0-beta.2 <= 1.5.0` and the check answers `UpToDate`. Live proof from a real install's log:

```
update check finished outcome=UpToDate { latest: "1.5.0-beta.2" }
```

The testing channel could never deliver anything. Worse, it does not self-heal: when `1.5.0` final ships, the manifest version and the reported version are **equal**, so beta users would go on being told they are up to date, stranded until `1.5.1`.

## Root cause

Not MSBuild, and not the version resolution — the release run's log shows `Building version: 1.5.0-beta.2` correctly.

The build passed `/p:Version` to **one** MSBuild invocation. `dotnet test` then rebuilds the plugin project it references, *without* that property, falls back to `VersionPrefix`, and overwrites the assembly. `copy to dist` runs after the test step, so it packages those bytes.

Reproduced locally, which is what turned it from theory into fact:

```
BEFORE: 1.5.0-beta.9+f246573…     (msbuild /p:Version=1.5.0-beta.9)
AFTER:  1.5.0+f246573…            (after dotnet test)
```

## The fix

Make the version something every MSBuild invocation **reads**, rather than an argument one of them is **given**:

- the resolve step exports `MBRC_VERSION` to `$GITHUB_ENV`, so it reaches the explicit build, the test step's implicit rebuild, and any step added later;
- `Directory.Build.props` takes `Version` from it when set.

`MBRC_VERSION` already existed for the Rust core — which was silently mis-stamped the same way, since the variable was scoped to the one step that also drives the cargo build. Both sides now follow one source, and `/p:Version` is no longer load-bearing.

**Plus a guard.** None of this was visible in a green build; it shipped twice and was only found when a tester was never offered an update. The stamp is now asserted against the resolved version immediately before the dist copy, after everything that could have rebuilt the assembly. It compares the part before `+`, so `1.5.0` cannot pass as a prefix of `1.5.0-beta.2`.

## Testing

Local, with the exact failure reproduced first:

| | InformationalVersion |
| --- | --- |
| `MBRC_VERSION` set, after `msbuild` | `1.5.0-beta.9+…` |
| …after `dotnet test` (was the bug) | `1.5.0-beta.9+…` ✅ survives |
| No `MBRC_VERSION` (dev build) | `1.5.0+…` — unchanged |

**Verified live in the app:** a Debug build stamped `MBRC_VERSION=1.5.0-beta.3-dev` shows `v1.5.0-beta.3-dev` in the Configure panel footer. That string can only exist if `Directory.Build.props` picked the version out of the environment.

Note the panel footer is the same string handed to the update check, so it doubles as an at-a-glance test: a beta build whose footer reads plain `v1.5.0` is mis-stamped and its updater is dead. `AssemblyVersion` and `AssemblyFileVersion` are `1.5.0.0` in every case and can never reveal this — only `InformationalVersion` carries it.

**Not yet exercised:** a real CI run. A `workflow_dispatch` dry run of `release.yml` on this branch builds, packages and signs without publishing, which would confirm both the stamp and the new guard step before any release is cut.

## Operational note

This fix cannot reach the installs that already have the bug. **beta.1 and beta.2 report `1.5.0` and will not auto-update to beta.3** — those need one manual install. Worth saying in the beta.3 release notes.
