### PR TITLE
fix(update): remove the staging directory a successful update leaves behind

### DIFF
--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -175,6 +175,17 @@ fn run_thread(
         let cache_core = core.clone();
         tokio::task::spawn_blocking(move || reconcile_library(&cache_core));
 
+        // Sweep the staging directory of an update that has already been applied.
+        // The helper cannot remove it (it runs from inside it), so it falls to the
+        // next start - which this is. Not gated on the update preference: the
+        // residue exists whether or not the user wants checks, and it is a few
+        // megabytes per release if nobody clears it. Blocking, so off the async
+        // workers.
+        let sweep_storage = core.config.storage_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::updates::sweep_applied_staging(&sweep_storage);
+        });
+
         // One update check per session, and only if the user asked for them.
         // Delayed so it does not compete with the library reconcile and cover
         // build above, which are what MusicBee was actually opened for; the

--- a/packages/mbrc-core/src/updates/mod.rs
+++ b/packages/mbrc-core/src/updates/mod.rs
@@ -96,6 +96,52 @@ pub fn stage_update(
     Ok(staged)
 }
 
+/// Removes a staged bundle that has already been applied.
+///
+/// The helper cannot do this for itself. It runs from inside
+/// `<storage>/updates/<version>/mbrc-helper.exe`, and Windows will not unlink a
+/// running image, so the `remove_dir_all` in its own `clear_staged` fails on
+/// *every* successful update - silently, because the helper is launched with no
+/// console and the failure only reaches `eprintln!`. It does manage to delete
+/// `pending.json`, which lives one directory up, so the marker goes and the
+/// bundle stays.
+///
+/// By the time the core is running again the helper has exited and the directory
+/// is nothing but residue, so this is the right place to sweep it. The whole
+/// `updates/` root goes, not just one version: `stage` only clears the directory
+/// for the version it is about to write, so earlier versions accumulate too.
+///
+/// A pending marker means a bundle is staged and waiting to be applied - that is
+/// live state, and it is left alone.
+pub fn sweep_applied_staging(storage_path: &str) {
+    if storage_path.is_empty() {
+        return;
+    }
+    match stage::read_pending(storage_path) {
+        // Still waiting to be applied: not ours to remove.
+        Ok(Some(pending)) => {
+            tracing::debug!(version = %pending.version, "leaving a staged update in place");
+            return;
+        }
+        Ok(None) => {}
+        Err(e) => {
+            // An unreadable marker is not licence to delete what it describes.
+            tracing::warn!(error = %e, "not sweeping staged updates: the marker is unreadable");
+            return;
+        }
+    }
+
+    let root = std::path::Path::new(storage_path).join(stage::STAGING_DIR);
+    if !root.exists() {
+        return;
+    }
+    match stage::clear_staged(storage_path) {
+        Ok(()) => tracing::info!("removed an applied update's staging directory"),
+        // Not worth failing anything over: it costs disk, not correctness.
+        Err(e) => tracing::warn!(error = %e, "could not remove the staging directory"),
+    }
+}
+
 /// Records that the user does not want to be offered `version` again.
 pub fn skip_version(config: &Config, version: &str) -> Result<()> {
     let mut state = load_state(&config.storage_path);
@@ -154,6 +200,63 @@ mod tests {
         assert_eq!(options.repo, check::DEFAULT_REPO);
         // The compiled-in release keys, not an empty or test trust list.
         assert!(!options.keys.is_empty());
+    }
+
+    /// A storage dir with a staged bundle in it, optionally with the pending
+    /// marker that says it is still waiting to be applied.
+    fn staged_fixture(case: &str, pending: bool) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("mbrc-sweep-{case}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        let version_dir = dir.join("updates").join("1.5.0-beta.2");
+        std::fs::create_dir_all(&version_dir).expect("create staging dir");
+        // The file the helper cannot delete, because it is running from it.
+        std::fs::write(version_dir.join("mbrc-helper.exe"), b"stand-in").expect("seed helper");
+        std::fs::write(version_dir.join("mb_remote.dll"), b"stand-in").expect("seed dll");
+        if pending {
+            std::fs::write(
+                dir.join("updates").join("pending.json"),
+                br#"{"schema":1,"version":"1.5.0-beta.2","staged_at":"2026-08-22T11:34:26Z"}"#,
+            )
+            .expect("seed marker");
+        }
+        dir
+    }
+
+    #[test]
+    fn an_applied_bundle_is_swept() {
+        // No marker: the helper applied it and cleared the marker but could not
+        // remove its own directory. This is the leak.
+        let dir = staged_fixture("applied", false);
+        sweep_applied_staging(dir.to_str().expect("utf8 dir"));
+        assert!(
+            !dir.join("updates").exists(),
+            "the applied bundle should have been removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_bundle_still_waiting_is_left_alone() {
+        // A marker means it is staged for the next restart - live state, not
+        // residue. Sweeping it would silently cancel the user's update.
+        let dir = staged_fixture("pending", true);
+        sweep_applied_staging(dir.to_str().expect("utf8 dir"));
+        assert!(
+            dir.join("updates").join("1.5.0-beta.2").exists(),
+            "a pending update must survive the sweep"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sweeping_nothing_is_not_an_error() {
+        // A fresh install that has never staged anything, and the no-storage case.
+        let dir = std::env::temp_dir().join("mbrc-sweep-empty");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        sweep_applied_staging(dir.to_str().expect("utf8 dir"));
+        sweep_applied_staging("");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## The leak

Every successful update leaves its staged bundle on disk — about 5 MB per release, one directory per version, never collected. Found while inspecting a real install right after it applied `1.5.0-beta.2`:

```
updates/1.5.0-beta.2/mb_remote.dll
updates/1.5.0-beta.2/mbrc_core.dll
updates/1.5.0-beta.2/mbrc-helper.exe      5.4 MB, marker already gone
```

## Why the helper cannot fix it itself

`update::clear_staged` is meant to remove exactly this. It is structurally unable to:

```
helper   = …\updates\1.5.0-beta.2\mbrc-helper.exe      ← running from here
clear_staged → remove_dir_all(…\updates\1.5.0-beta.2)  ← deletes its own image
```

Windows will not unlink a running executable, so the call fails **every time**. It does succeed in deleting `pending.json`, which lives one directory up — so the marker disappears and the bundle stays, which looks indistinguishable from a clean apply.

Three things kept this invisible:

- the failure only reaches `eprintln!`, and the helper is launched via `ShellExecuteExW` with no console attached;
- the comment calls it *"best effort and deliberately not fatal"*, which is fair for a transient failure — this one is systematic;
- nothing collects it later. `stage()` clears only the directory for the version it is about to write, so each version accumulates its own, and `mbrc-core` had **no call site for `clear_staged` at all**.

## The fix

Sweep at the next start, which is the first moment it is possible — the helper has exited and nothing is mapped from that directory any more. The whole `updates/` root goes, so it also collects anything earlier versions left behind.

Deliberate boundaries:

- **A pending marker is live state, not residue.** If a bundle is staged and waiting to be applied, it is left alone — sweeping it would silently cancel the user's update.
- **An unreadable marker is not licence to delete what it describes**, so a parse error leaves everything in place.
- **The rollback `backup/` is untouched.** That one is intentional and already self-limiting: the helper's `prune_backups` keeps the newest and removes the rest.
- **Not gated on `update_check_enabled`.** The residue exists whether or not the user wants checks.
- Runs on `spawn_blocking`, off the async workers, like the reconcile beside it.

## Testing

Three unit tests covering both branches and the empty case: an applied bundle is swept, a pending one survives, and a fresh install (plus the no-storage-path case) is a no-op. Full suite **203 pass**; `cargo fmt` and `clippy -D warnings` clean.

**Verified against real residue**, not a fixture — the 5.4 MB left by the beta.2 update this install applied earlier today:

```
2026-08-22T11:42:47  INFO mbrc_core::updates: removed an applied update's staging directory
```

`updates/` gone after the restart, `backup/` still present.

## Worth having in beta.3

Every tester who takes an update collects a folder per release otherwise, and the first release where anyone *can* take an update is beta.3 (see #176 — until that landed, no beta was ever offered one).
