### PR TITLE
fix(plugin): open the log folder on the Store build

### DIFF
--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using MusicBeePlugin.Ffi;
 using MusicBeePlugin.Ffi.Generated;
 using MusicBeePlugin.Host;
+using MusicBeePlugin.Utilities;
 
 namespace MusicBeePlugin.Settings
 {
@@ -895,7 +896,11 @@ namespace MusicBeePlugin.Settings
             if (string.IsNullOrEmpty(_bundlePath) || !File.Exists(_bundlePath)) return;
             try
             {
-                Process.Start(new ProcessStartInfo("explorer.exe", "/select,\"" + _bundlePath + "\"")
+                // Usually the Desktop, which MSIX does not redirect - but the
+                // capture falls back to the log folder when no Desktop resolves,
+                // and that one is redirected on the Store build.
+                var shown = PackagePaths.ForExternalProcess(_bundlePath);
+                Process.Start(new ProcessStartInfo("explorer.exe", "/select,\"" + shown + "\"")
                 {
                     UseShellExecute = true
                 });
@@ -916,7 +921,15 @@ namespace MusicBeePlugin.Settings
                     SetStatus("Log folder not found.", false);
                     return;
                 }
-                Process.Start(new ProcessStartInfo(dir) { UseShellExecute = true });
+                // Explorer runs outside our process. On the Store build that
+                // matters: MSIX redirects %APPDATA%, so the path we just confirmed
+                // exists is one Explorer cannot resolve, and it reports "Location
+                // is not available". The Directory.Exists above cannot catch that -
+                // from in here the path really does exist.
+                Process.Start(new ProcessStartInfo(PackagePaths.ForExternalProcess(dir))
+                {
+                    UseShellExecute = true
+                });
             }
             catch (Exception ex)
             {

--- a/packages/plugin/Utilities/PackagePaths.cs
+++ b/packages/plugin/Utilities/PackagePaths.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace MusicBeePlugin.Utilities
+{
+    /// <summary>
+    ///     Translates a path this process sees into one another process can open.
+    ///
+    ///     The Microsoft Store build of MusicBee is an MSIX package, and MSIX
+    ///     redirects <c>%APPDATA%</c> transparently: the packaged process asks for
+    ///     <c>C:\Users\x\AppData\Roaming\MusicBee\mb_remote</c> and the bytes land in
+    ///     <c>%LOCALAPPDATA%\Packages\&lt;family&gt;\LocalCache\Roaming\MusicBee\mb_remote</c>.
+    ///     Everything inside the container works, because the redirection is
+    ///     invisible to it - the core logs the un-redirected path, reads and writes
+    ///     it happily, and <see cref="Directory.Exists" /> agrees it is there.
+    ///
+    ///     It only breaks when the path leaves the container. Explorer runs
+    ///     outside, resolves it literally, and reports "Location is not available"
+    ///     for a folder that on that install does not exist at all - the real
+    ///     <c>%APPDATA%\MusicBee</c> is never created.
+    ///
+    ///     That is also why an existence check cannot catch it: from in here the
+    ///     path does exist. Detection has to be package identity.
+    /// </summary>
+    public static class PackagePaths
+    {
+        /// <summary>The process has no package identity (i.e. it is not packaged).</summary>
+        private const int AppModelErrorNoPackage = 15700;
+
+        private const int ErrorInsufficientBuffer = 122;
+
+        /// <summary>Where MSIX puts a packaged app's redirected roaming AppData.</summary>
+        private const string ContainerRoamingSuffix = @"LocalCache\Roaming";
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern int GetCurrentPackageFamilyName(ref uint length, StringBuilder name);
+
+        private static readonly Lazy<string> Family = new Lazy<string>(ReadPackageFamilyName);
+
+        /// <summary>
+        ///     The package family name (e.g.
+        ///     <c>50072StevenMayall.MusicBee_kcr266et74avj</c>), or empty when this
+        ///     process is not packaged - which is the normal desktop install.
+        /// </summary>
+        public static string PackageFamilyName => Family.Value;
+
+        /// <summary>Whether MusicBee is running as a packaged (Store) app.</summary>
+        public static bool IsPackaged => !string.IsNullOrEmpty(Family.Value);
+
+        /// <summary>
+        ///     A path safe to hand to a process outside this one - Explorer, for
+        ///     instance.
+        ///
+        ///     Unpackaged, or for a path that is not under roaming AppData (a
+        ///     portable install keeps its storage beside the executable), the input
+        ///     is returned untouched.
+        ///
+        ///     The translation is only used when the translated path can be seen to
+        ///     exist. A wrong guess then costs nothing: the caller gets today's
+        ///     behaviour rather than a second, differently wrong path.
+        /// </summary>
+        public static string ForExternalProcess(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !IsPackaged) return path;
+
+            try
+            {
+                var translated = Translate(
+                    path,
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    PackageFamilyName);
+
+                if (string.Equals(translated, path, StringComparison.OrdinalIgnoreCase)) return path;
+                return Directory.Exists(translated) || File.Exists(translated) ? translated : path;
+            }
+            catch (Exception)
+            {
+                // Nothing here is worth failing an "open folder" button over.
+                return path;
+            }
+        }
+
+        /// <summary>
+        ///     The pure half: rewrite <paramref name="path" /> from the roaming
+        ///     AppData view into the package container's copy of it. Kept free of
+        ///     any OS lookup so it can be tested directly.
+        /// </summary>
+        /// <returns>
+        ///     The translated path, or <paramref name="path" /> unchanged when it is
+        ///     not under <paramref name="roamingRoot" />.
+        /// </returns>
+        public static string Translate(string path, string roamingRoot, string localRoot, string family)
+        {
+            if (string.IsNullOrEmpty(path) ||
+                string.IsNullOrEmpty(roamingRoot) ||
+                string.IsNullOrEmpty(localRoot) ||
+                string.IsNullOrEmpty(family))
+            {
+                return path;
+            }
+
+            // Already inside the container: translating again would nest a second
+            // LocalCache\Roaming under the first.
+            if (path.IndexOf(ContainerRoamingSuffix, StringComparison.OrdinalIgnoreCase) >= 0) return path;
+
+            var root = roamingRoot.TrimEnd('\\');
+            if (!path.StartsWith(root, StringComparison.OrdinalIgnoreCase)) return path;
+
+            // Only a whole path segment counts: %APPDATA% must not match
+            // "...\RoamingSomethingElse".
+            var remainder = path.Substring(root.Length);
+            if (remainder.Length > 0 && remainder[0] != '\\') return path;
+            remainder = remainder.TrimStart('\\');
+
+            var container = Path.Combine(localRoot.TrimEnd('\\'), "Packages", family, ContainerRoamingSuffix);
+            return remainder.Length == 0 ? container : Path.Combine(container, remainder);
+        }
+
+        /// <summary>
+        ///     Asks Windows for this process's package family name.
+        ///     <c>APPMODEL_ERROR_NO_PACKAGE</c> is the ordinary answer on a normal
+        ///     desktop install and means "not packaged", not "failed".
+        /// </summary>
+        private static string ReadPackageFamilyName()
+        {
+            try
+            {
+                uint length = 0;
+                var probe = GetCurrentPackageFamilyName(ref length, null);
+                if (probe == AppModelErrorNoPackage || length == 0) return string.Empty;
+                if (probe != ErrorInsufficientBuffer && probe != 0) return string.Empty;
+
+                var buffer = new StringBuilder((int)length);
+                return GetCurrentPackageFamilyName(ref length, buffer) == 0 ? buffer.ToString() : string.Empty;
+            }
+            catch (Exception)
+            {
+                // The export is Windows 8+. Older hosts are simply never packaged.
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/tests/csharp/Utilities/PackagePathsTests.cs
+++ b/tests/csharp/Utilities/PackagePathsTests.cs
@@ -1,0 +1,112 @@
+using AwesomeAssertions;
+using MusicBeePlugin.Utilities;
+using Xunit;
+
+namespace MusicBeeRemote.Core.Tests.Utilities
+{
+    /// <summary>
+    ///     The pure half of <see cref="PackagePaths" />. The package-identity lookup
+    ///     is a P/Invoke and is not exercised here; the mapping it feeds is, because
+    ///     that is where a mistake would send Explorer somewhere wrong.
+    /// </summary>
+    public class PackagePathsTests
+    {
+        // The real values from the Store install this was found on.
+        private const string Roaming = @"C:\Users\kelsos\AppData\Roaming";
+        private const string Local = @"C:\Users\kelsos\AppData\Local";
+        private const string Family = "50072StevenMayall.MusicBee_kcr266et74avj";
+
+        [Fact]
+        public void Translate_RewritesTheStoragePathIntoTheContainer()
+        {
+            var result = PackagePaths.Translate(
+                @"C:\Users\kelsos\AppData\Roaming\MusicBee\mb_remote", Roaming, Local, Family);
+
+            result.Should().Be(
+                @"C:\Users\kelsos\AppData\Local\Packages\50072StevenMayall.MusicBee_kcr266et74avj\LocalCache\Roaming\MusicBee\mb_remote");
+        }
+
+        [Fact]
+        public void Translate_RewritesAFileInsideTheStoragePath()
+        {
+            var result = PackagePaths.Translate(
+                @"C:\Users\kelsos\AppData\Roaming\MusicBee\mb_remote\mbrc-core.log", Roaming, Local, Family);
+
+            result.Should().EndWith(@"LocalCache\Roaming\MusicBee\mb_remote\mbrc-core.log");
+        }
+
+        [Fact]
+        public void Translate_LeavesAPathOutsideRoamingAlone()
+        {
+            // A portable install keeps its storage beside the executable.
+            const string portable = @"C:\dev\mbrc-plugin\app\MusicBee\AppData\mb_remote";
+            PackagePaths.Translate(portable, Roaming, Local, Family).Should().Be(portable);
+
+            // And the Desktop, which MSIX does not redirect.
+            const string desktop = @"C:\Users\kelsos\Desktop\mbrc-diagnostics-20260822-115124.zip";
+            PackagePaths.Translate(desktop, Roaming, Local, Family).Should().Be(desktop);
+        }
+
+        [Fact]
+        public void Translate_IsIdempotent()
+        {
+            // Translating twice must not nest a second LocalCache\Roaming inside
+            // the first - the panel can hand back a path it was already given.
+            var once = PackagePaths.Translate(
+                @"C:\Users\kelsos\AppData\Roaming\MusicBee\mb_remote", Roaming, Local, Family);
+            PackagePaths.Translate(once, Roaming, Local, Family).Should().Be(once);
+        }
+
+        [Fact]
+        public void Translate_OnlyMatchesAWholeSegment()
+        {
+            // "%APPDATA%" must not swallow a sibling directory that merely starts
+            // with the same characters.
+            const string sibling = @"C:\Users\kelsos\AppData\RoamingBackup\MusicBee";
+            PackagePaths.Translate(sibling, Roaming, Local, Family).Should().Be(sibling);
+        }
+
+        [Fact]
+        public void Translate_IsCaseInsensitiveOnTheRoot()
+        {
+            // MusicBee's own answer is not guaranteed to match the CLR's casing.
+            var result = PackagePaths.Translate(
+                @"c:\users\kelsos\appdata\roaming\MusicBee\mb_remote", Roaming, Local, Family);
+
+            result.Should().EndWith(@"LocalCache\Roaming\MusicBee\mb_remote");
+        }
+
+        [Fact]
+        public void Translate_HandlesTheRoamingRootItself()
+        {
+            PackagePaths.Translate(Roaming, Roaming, Local, Family)
+                .Should().Be(@"C:\Users\kelsos\AppData\Local\Packages\" + Family + @"\LocalCache\Roaming");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Translate_PassesEmptyInputThrough(string path)
+        {
+            PackagePaths.Translate(path, Roaming, Local, Family).Should().Be(path);
+        }
+
+        [Fact]
+        public void Translate_WithoutAFamilyNameChangesNothing()
+        {
+            // Not packaged: there is no container to point at.
+            const string path = @"C:\Users\kelsos\AppData\Roaming\MusicBee\mb_remote";
+            PackagePaths.Translate(path, Roaming, Local, string.Empty).Should().Be(path);
+        }
+
+        [Fact]
+        public void ForExternalProcess_IsAPassThroughWhenNotPackaged()
+        {
+            // The test host is never a packaged app, so this exercises the guard.
+            PackagePaths.IsPackaged.Should().BeFalse();
+
+            const string path = @"C:\Users\kelsos\AppData\Roaming\MusicBee\mb_remote";
+            PackagePaths.ForExternalProcess(path).Should().Be(path);
+        }
+    }
+}


### PR DESCRIPTION
## The bug

On the Microsoft Store build, **"Open log folder" fails**, naming a folder that on that install does not exist at all:

> `C:\Users\kelsos\AppData\Roaming\MusicBee\mb_remote is unavailable.`

## Why

MusicBee's Store build is an MSIX package, and MSIX redirects `%APPDATA%` transparently. The packaged process asks for

```
C:\Users\x\AppData\Roaming\MusicBee\mb_remote
```

and the bytes land in

```
%LOCALAPPDATA%\Packages\<family>\LocalCache\Roaming\MusicBee\mb_remote
```

Everything *inside* the container works on the un-redirected path — the core logs it as its storage path, reads and writes it happily, and `Directory.Exists` agrees it is there. It only breaks when the path leaves the container: Explorer runs outside, resolves it literally, and finds nothing. On such an install `%APPDATA%\MusicBee` is never created — verified with `Test-Path`, which returns `False`.

That is also why the existence check already in `OpenLogFolder` cannot catch it. From inside the package the path *does* exist, so the guard passes and Explorer fails afterwards. Detection has to be **package identity**, not the filesystem.

## The fix

`PackagePaths` asks Windows for the package family name — `APPMODEL_ERROR_NO_PACKAGE` is the ordinary answer on a normal desktop install and means "not packaged", not "failed" — and rewrites a roaming-AppData path into the container's copy.

Applied at the two places a path is handed to Explorer:

- **the log folder**;
- **revealing a diagnostics bundle** — that usually lands on the Desktop, which MSIX does *not* redirect, but the capture falls back to the log folder when no Desktop resolves, and that one is redirected.

Deliberate boundaries:

- **Only used when the translated path can be seen to exist.** A wrong guess then costs nothing — the caller gets today's behaviour rather than a second, differently wrong path.
- **Anything outside roaming AppData passes through**, so a portable install (storage beside the executable) and the Desktop are untouched.
- **Idempotent**: translating a path that is already inside the container must not nest a second `LocalCache\Roaming` under the first.
- **Whole-segment matching**, so `%APPDATA%` cannot swallow a sibling like `…\RoamingBackup`.

## Testing

The mapping is kept free of any OS lookup so it is directly testable; the P/Invoke is the only untested part. 11 tests use the real paths from the install this was found on, covering the rewrite, the pass-throughs, idempotency, whole-segment matching, case-insensitivity, and the not-packaged guard. C# suite **72 pass** (was 61); `dotnet format --verify-no-changes` clean.

**Verified on the Store install itself.** Built Release, backed up the three existing plugin files, deployed into the packaged app's plugins folder, relaunched, and the button now opens the container folder instead of raising the error dialog.

## Note

This was the last of the two blockers found while testing the update flow for beta.3; the other was #176.
