### PR TITLE
fix(update): make the Store build's update path diagnosable, and try to fix it

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -211,7 +211,13 @@ running as administrator, so the boundaries are part of the design:
 ## Applying
 
 `mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>`,
-run elevated. In order: re-verify, wait, back up, swap, roll back if needed.
+plus `--relaunch-aumid <aumid>` when MusicBee is a packaged (Store) install. In
+order: re-verify, wait, back up, swap, roll back if needed.
+
+Everything it prints also goes to `mbrc-helper.log` beside the plugin's other
+logs, falling back to `%TEMP%` when that directory cannot be written. The helper
+is launched with no console, so before that log existed every failure in it was
+silent - including two that stopped the Store build updating at all.
 
 **Re-verification comes first and is not a formality.** The staged bundle sits
 where any user process can write, so nothing in it is trusted because the core
@@ -264,6 +270,13 @@ MusicBee is relaunched **through Explorer**, not as a child of the helper. A chi
 would inherit elevation and run MusicBee as administrator for the rest of the
 session, writing its settings and cache as the wrong user.
 
+A **packaged (Store) MusicBee cannot be relaunched by path**: Windows denies
+executing the image under `WindowsApps` directly, and handing Explorer that path
+activates nothing while reporting success. The core therefore derives its
+Application User Model ID and passes `--relaunch-aumid`, and the helper starts
+`shell:AppsFolder\<AUMID>` instead. The AUMID is derived, never accepted from the
+host, for the same reason nothing else here is.
+
 ### Getting there: `mbrc_apply_staged_update()`
 
 The panel calls one FFI export that takes **no arguments**. The storage directory
@@ -280,7 +293,7 @@ runs elevated out of a user-writable directory, so checking it before *execution
 - earlier than the check it then performs on the DLLs - is the boundary.
 
 The file is opened **denying write and delete sharing**, verified through that
-handle, and the handle is held open across `ShellExecuteExW`. Verifying by path
+handle, and the handle is held open across the launch. Verifying by path
 and then launching by path would leave a window in which any process running as
 the user could replace the file after it verified and have its own binary run as
 administrator, on the prompt the user was expecting. Execution still works:
@@ -292,9 +305,16 @@ proves a bundle is ours, not that it is the right one to install - without this,
 anyone able to write to the staging directory could roll the plugin back to an
 older release, signature and all, and undo whatever the newer one fixed.
 
-Elevation is requested with `ShellExecuteExW` and the `runas` verb, chosen by
-probing whether the plugins directory is writable (by writing, not by reading an
-ACL). The prompt therefore appears while the user is still looking at the button
+The helper is started as an **ordinary child process** when the plugins directory
+is already writable, and through `ShellExecuteExW` with the `runas` verb when it
+is not - chosen by probing (by writing, not by reading an ACL).
+
+That distinction matters beyond the prompt. `ShellExecuteExW` hands the launch to
+Explorer, and a process Explorer starts is *outside* MusicBee's package
+container - so on a Store install the virtualized paths in the helper's argv
+resolved to nothing and it refused to act, correctly, on arguments it could not
+make sense of. A direct child inherits the container and sees what the core sees.
+`CreateProcess` cannot elevate, which is why the other path stays. The prompt therefore appears while the user is still looking at the button
 they pressed. Declining it comes back as `ERROR_CANCELLED` and is reported as a
 normal outcome with the staged download intact - the concrete gain over letting
 the helper self-elevate, where the prompt would arrive after MusicBee had already

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -79,6 +79,10 @@ windows-sys = { version = "=0.61.2", features = [
     "Win32_System_Registry",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
+    # GetCurrentApplicationUserModelId, to tell a packaged (Store) MusicBee from
+    # an ordinary one. A packaged app cannot be started by path, so the update
+    # helper has to be told the identity to activate instead.
+    "Win32_Storage_Packaging_Appx",
 ] }
 
 [build-dependencies]

--- a/packages/mbrc-core/src/diagnostics/bundle.rs
+++ b/packages/mbrc-core/src/diagnostics/bundle.rs
@@ -130,7 +130,9 @@ fn extra_logs(storage: &str, started_unix_ms: i64) -> Vec<PathBuf> {
         // The active log is already in the bundle as capture.log.
         .filter(|path| path != &active)
         .collect();
-    for name in ["mbrc-bootstrap.log", "mbrc.log"] {
+    // `mbrc-helper.log` is the elevated helper's only voice - it runs with no
+    // console, so without this a failed update is invisible in a bundle.
+    for name in ["mbrc-bootstrap.log", "mbrc.log", "mbrc-helper.log"] {
         let path = Path::new(storage).join(name);
         if path.is_file() {
             paths.push(path);

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -139,8 +139,9 @@ fn is_upgrade(staged: &str, installed: &str) -> bool {
 /// A staged helper that has verified, with the handle that keeps it that way.
 ///
 /// Holding `_handle` open is what makes the verification mean anything at launch
-/// time: it denies write and delete sharing, so between the hash check and
-/// `ShellExecuteExW` the file cannot be rewritten, renamed or replaced.
+/// time: it denies write and delete sharing, so between the hash check and the
+/// launch the file cannot be rewritten, renamed or replaced. That holds for both
+/// launch mechanisms - the shell ends up in `CreateProcess` too.
 struct VerifiedHelper {
     path: PathBuf,
     version: String,
@@ -208,7 +209,7 @@ fn log_verified(manifest: &Manifest, key: &str) {
 
 /// `update --pid <us> --staged <dir> --target <dir> --relaunch <exe>`.
 fn arguments(staged: &Path, target: &Path, relaunch: &Path) -> Vec<String> {
-    vec![
+    let mut args = vec![
         "update".into(),
         "--pid".into(),
         std::process::id().to_string(),
@@ -218,7 +219,55 @@ fn arguments(staged: &Path, target: &Path, relaunch: &Path) -> Vec<String> {
         target.display().to_string(),
         "--relaunch".into(),
         relaunch.display().to_string(),
-    ]
+    ];
+    // Only a packaged (Store) MusicBee has one, and only a packaged MusicBee
+    // needs it: Windows refuses to execute the image under `WindowsApps`
+    // directly, so the path above cannot start it and the package has to be
+    // activated by identity instead.
+    //
+    // Derived here rather than accepted from the host, which is the rule this
+    // whole module is built on: nothing is taken from the caller, so there is
+    // nothing to tamper with. The core runs inside MusicBee, so it is entitled to
+    // ask Windows who it is.
+    if let Some(aumid) = current_aumid() {
+        args.push("--relaunch-aumid".into());
+        args.push(aumid);
+    }
+    args
+}
+
+/// This process's Application User Model ID, or `None` when it has no package
+/// identity - which is the ordinary desktop install and by far the common case.
+#[cfg(windows)]
+fn current_aumid() -> Option<String> {
+    use windows_sys::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS};
+    use windows_sys::Win32::Storage::Packaging::Appx::GetCurrentApplicationUserModelId;
+
+    let mut length: u32 = 0;
+    // SAFETY: a null buffer with a zero length is the documented way to ask for
+    // the required size; nothing is written through the pointer.
+    let probe = unsafe { GetCurrentApplicationUserModelId(&mut length, std::ptr::null_mut()) };
+    // APPMODEL_ERROR_NO_PACKAGE lands here for an unpackaged process. It is the
+    // normal answer, not a failure, so it is not logged as one.
+    if probe != ERROR_INSUFFICIENT_BUFFER || length == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u16; length as usize];
+    // SAFETY: `buffer` has `length` units, which is what the probe asked for.
+    let result = unsafe { GetCurrentApplicationUserModelId(&mut length, buffer.as_mut_ptr()) };
+    if result != ERROR_SUCCESS {
+        tracing::warn!(result, "could not read this process's application id");
+        return None;
+    }
+    // The length includes the terminating null.
+    let end = (length as usize).saturating_sub(1).min(buffer.len());
+    Some(String::from_utf16_lossy(&buffer[..end]))
+}
+
+#[cfg(not(windows))]
+fn current_aumid() -> Option<String> {
+    None
 }
 
 /// Whether this process can write to `dir`, tested by writing rather than by
@@ -282,16 +331,74 @@ fn plugins_dir() -> Option<PathBuf> {
 
 /// Starts the helper, with an elevation prompt when `elevate` is set.
 ///
+/// Two different mechanisms, because they want different things: an ordinary
+/// child process when no elevation is needed (see [`spawn_direct`]), and the
+/// shell's `runas` verb when it is - `CreateProcess` cannot elevate.
+///
 /// `runas` is what produces the UAC prompt. A declined prompt comes back as
 /// `ERROR_CANCELLED`, which is a distinct outcome rather than a failure: the
-/// staged download is untouched and the user can press the button again.
+/// staged download is untouched and the user can press the button again. That
+/// outcome is unreachable on the direct path, correctly - there is no prompt to
+/// decline.
 #[cfg(windows)]
 fn spawn(exe: &Path, arguments: &[String], elevate: bool) -> UpdateLaunch {
+    if !elevate {
+        return spawn_direct(exe, arguments);
+    }
+    spawn_elevated(exe, arguments)
+}
+
+/// Starts the helper as an ordinary child process.
+///
+/// `CreateProcess` rather than the shell, and that distinction is the whole fix
+/// for the Store build. `ShellExecuteExW` hands the launch to Explorer, and a
+/// process Explorer starts is **outside** MusicBee's package container - so the
+/// paths in its argv, which MSIX virtualizes, resolve to nothing and the helper
+/// correctly refuses to act on them. A direct child inherits the container and
+/// sees exactly what the core sees.
+///
+/// It also removes a step that was never wanted here: the shell was only ever
+/// being used for its `runas` verb, which this path does not need.
+///
+/// The verified-helper handle the caller is holding stays meaningful. It denies
+/// write and delete sharing while permitting read, and Windows counts the image
+/// loader's `FILE_EXECUTE` as read - so the file can be executed but not swapped
+/// between the hash check and this call. Rust opens files non-inheritable, so the
+/// handle is not passed to the child either.
+///
+/// # Unverified, and one known risk
+///
+/// A packaged MusicBee runs inside a **job object** (confirmed with
+/// `IsProcessInJob`), and a `CreateProcess` child joins its parent's job. If that
+/// job terminates its processes when the app exits, this helper dies at exactly
+/// the moment it stops waiting and starts work - which would make this change
+/// worse than what it replaces, not better. `CREATE_BREAKAWAY_FROM_JOB` is the
+/// escape hatch, but only if the job permits breakaway.
+///
+/// Neither the container inheritance this relies on nor the job behaviour above
+/// has been observed on a real Store install: the helper that runs is always the
+/// *staged* one, so only a release built from this code can exercise it. The
+/// first hop that can is beta.3 -> beta.4. If it turns out wrong, the fallback is
+/// to keep the shell launch and have the core resolve the real container paths
+/// (`GetFinalPathNameByHandleW`) before passing them, which depends on neither.
+#[cfg(windows)]
+fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
+    match std::process::Command::new(exe).args(arguments).spawn() {
+        Ok(_) => UpdateLaunch::Launched,
+        Err(e) => {
+            tracing::error!(error = %e, "could not start the update helper");
+            UpdateLaunch::Failed
+        }
+    }
+}
+
+#[cfg(windows)]
+fn spawn_elevated(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     use windows_sys::Win32::Foundation::{GetLastError, ERROR_CANCELLED};
     use windows_sys::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SHELLEXECUTEINFOW};
     use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
-    let verb = wide(if elevate { "runas" } else { "open" });
+    let verb = wide("runas");
     let file = wide(&exe.display().to_string());
     let parameters = wide(&quote(arguments));
 
@@ -409,8 +516,18 @@ mod tests {
         assert_eq!(args[0], "update");
         assert_eq!(args[2], std::process::id().to_string());
         // The helper parses `--flag value` pairs and rejects anything else, so
-        // the shape matters as much as the values.
-        assert_eq!(args.len(), 9);
+        // the shape matters as much as the values. Nine, or eleven when this
+        // process is a packaged app and `--relaunch-aumid` is appended - which a
+        // test runner never is, but the assertion should say why it is nine.
+        assert!(
+            args.len() == 9 || args.len() == 11,
+            "unexpected argv shape: {args:?}"
+        );
+        assert_eq!(
+            args.len() == 11,
+            args.iter().any(|a| a == "--relaunch-aumid"),
+            "the extra pair is the AUMID or nothing"
+        );
         for flag in ["--pid", "--staged", "--target", "--relaunch"] {
             assert!(args.iter().any(|a| a == flag), "{flag} is missing");
         }

--- a/packages/mbrc-helper/src/log.rs
+++ b/packages/mbrc-helper/src/log.rs
@@ -147,8 +147,12 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    fn scratch_root(case: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("mbrc-helper-log-{case}"))
+    }
+
     fn scratch(case: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("mbrc-helper-log-{case}"));
+        let dir = scratch_root(case);
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("create scratch dir");
         dir
@@ -180,15 +184,24 @@ mod tests {
         // than the real temp directory, so the suite never writes into the log a
         // user is actually asked to read.
         let fallback = scratch("fallback");
-        let staged = Path::new(r"Z:\no-such-volume\mb_remote\updates\1.5.0");
+        // Absolute, so it is a real staging path on either platform, but pointing
+        // into a directory that does not exist - a Windows-shaped literal like
+        // `Z:\...` is one component with no parent on Linux and would take the
+        // "never a path" branch instead, testing nothing.
+        let staged = scratch("unreachable")
+            .join("no-such-directory")
+            .join("mb_remote")
+            .join("updates")
+            .join("1.5.0");
 
         assert_eq!(
-            choose_sink(staged, &fallback),
+            choose_sink(&staged, &fallback),
             Some(fallback.join(LOG_FILE)),
             "an unreachable storage directory must not silence the log"
         );
 
         let _ = std::fs::remove_dir_all(&fallback);
+        let _ = std::fs::remove_dir_all(scratch_root("unreachable"));
     }
 
     #[test]

--- a/packages/mbrc-helper/src/log.rs
+++ b/packages/mbrc-helper/src/log.rs
@@ -1,0 +1,238 @@
+//! Somewhere for the helper to say what happened.
+//!
+//! The helper is launched without a console, so every `println!` and `eprintln!`
+//! in it goes nowhere. That is not a cosmetic gap: two real bugs - the helper
+//! being unable to resolve its own arguments on a packaged install, and being
+//! unable to relaunch a packaged MusicBee - both failed here in total silence.
+//! MusicBee closed, nothing was applied, and the only signal was an exit code
+//! nobody was left running to read.
+//!
+//! So every line the helper prints is also appended to `mbrc-helper.log` beside
+//! the plugin's other logs. Printing continues: it costs nothing when there is no
+//! console and it is how the helper is read when run by hand, which is how the
+//! first of those bugs was actually found.
+//!
+//! Deliberately not a logging framework. The helper is a short-lived process that
+//! writes a handful of lines; a dependency, a filter and a level system would all
+//! be scaffolding around `writeln!`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// The log's name, beside `mbrc-core.log` in the plugin's storage directory.
+const LOG_FILE: &str = "mbrc-helper.log";
+
+/// Where lines are being written, once somewhere has been chosen.
+///
+/// Resolved on first use rather than at startup because the storage directory is
+/// derived from the `--staged` argument, which is not known until argv is parsed
+/// - and a failure while parsing argv is exactly the kind worth recording.
+static SINK: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+fn sink() -> std::sync::MutexGuard<'static, Option<PathBuf>> {
+    SINK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Point the log at the storage directory derived from `staged`.
+///
+/// `staged` is `<storage>/updates/<version>`, so the storage directory is two
+/// levels up - the same derivation `update::backup_root` uses, kept consistent
+/// with it deliberately.
+///
+/// Falls back to the temp directory when that cannot be written. This is not a
+/// theoretical fallback: a helper that started outside its package container
+/// cannot see the storage directory at all, and that is precisely the failure
+/// this log exists to make visible.
+pub fn direct_to_storage(staged: &Path) {
+    *sink() = choose_sink(staged, &std::env::temp_dir());
+}
+
+/// Where a line would go, given a staging directory and a fallback directory.
+///
+/// Split from [`direct_to_storage`] so it can be tested without the fallback
+/// resolving to the real temp directory - a test writing into the actual
+/// `%TEMP%/mbrc-helper.log` would leave its fixtures in a file a user is later
+/// asked to read, and a diagnostics bundle would collect them.
+///
+/// `None` when `staged` is not a real staging path at all, which only a caller
+/// bug produces. The fallback is for a storage directory that exists and cannot
+/// be written - the outside-the-container case - not for arguments that were
+/// never a path; inventing a log file for those is how the test suite ended up
+/// writing into the user's.
+fn choose_sink(staged: &Path, fallback_dir: &Path) -> Option<PathBuf> {
+    let storage = staged.parent().and_then(Path::parent)?;
+    if !storage.is_absolute() {
+        return None;
+    }
+    let beside_the_others = storage.join(LOG_FILE);
+    if writable(&beside_the_others) {
+        return Some(beside_the_others);
+    }
+    Some(fallback_dir.join(LOG_FILE))
+}
+
+/// Record a line, and print it too.
+///
+/// Never fails and never panics: the helper is mid-way through replacing a
+/// plugin, and losing a log line is not a reason to change what it does.
+pub fn line(message: &str) {
+    eprintln!("mbrc-helper: {message}");
+    let guard = sink();
+    let Some(path) = guard.as_ref() else {
+        return;
+    };
+    let _ = append(path, message);
+}
+
+fn append(path: &Path, message: &str) -> std::io::Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{} mbrc-helper: {message}", timestamp())
+}
+
+/// Whether a line can actually be appended here, tested by opening rather than by
+/// checking the directory: under a package container the answer depends on who is
+/// asking, not on what the path looks like.
+fn writable(path: &Path) -> bool {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .is_ok()
+}
+
+/// A UTC timestamp in the same shape the core's log uses, so the two read
+/// together when both end up in a diagnostics bundle.
+fn timestamp() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Civil-from-days, so the helper does not take a date dependency for one line.
+    let (days, rem) = (now / 86_400, now % 86_400);
+    let (h, m, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let (y, mo, d) = civil_from_days(days as i64);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Howard Hinnant's `civil_from_days`, for days since the Unix epoch.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes the tests that move the sink, which is process-global because
+    /// the helper has exactly one log. Without this they race over it.
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    fn exclusive() -> std::sync::MutexGuard<'static, ()> {
+        TEST_GUARD
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn scratch(case: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mbrc-helper-log-{case}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    #[test]
+    fn writes_beside_the_other_logs() {
+        let _exclusive = exclusive();
+        let storage = scratch("storage");
+        let staged = storage.join("updates").join("1.5.0");
+        std::fs::create_dir_all(&staged).expect("create staged dir");
+
+        direct_to_storage(&staged);
+        line("applied 1.5.0 (3 file(s))");
+
+        let body = std::fs::read_to_string(storage.join(LOG_FILE)).expect("log written");
+        assert!(body.contains("applied 1.5.0"), "{body}");
+        // Timestamped, so two runs can be told apart.
+        assert!(body.starts_with("20"), "{body}");
+
+        *sink() = None;
+        let _ = std::fs::remove_dir_all(&storage);
+    }
+
+    #[test]
+    fn falls_back_when_the_storage_directory_is_unreachable() {
+        // What a helper started outside its package container sees: the storage
+        // path it was handed does not resolve. Uses a scratch fallback rather
+        // than the real temp directory, so the suite never writes into the log a
+        // user is actually asked to read.
+        let fallback = scratch("fallback");
+        let staged = Path::new(r"Z:\no-such-volume\mb_remote\updates\1.5.0");
+
+        assert_eq!(
+            choose_sink(staged, &fallback),
+            Some(fallback.join(LOG_FILE)),
+            "an unreachable storage directory must not silence the log"
+        );
+
+        let _ = std::fs::remove_dir_all(&fallback);
+    }
+
+    #[test]
+    fn prefers_the_storage_directory_when_it_is_writable() {
+        let storage = scratch("prefers");
+        let staged = storage.join("updates").join("1.5.0");
+        std::fs::create_dir_all(&staged).expect("create staged dir");
+        let fallback = scratch("prefers-fallback");
+
+        assert_eq!(
+            choose_sink(&staged, &fallback),
+            Some(storage.join(LOG_FILE))
+        );
+
+        let _ = std::fs::remove_dir_all(&storage);
+        let _ = std::fs::remove_dir_all(&fallback);
+    }
+
+    #[test]
+    fn an_argument_that_was_never_a_path_gets_no_log_file() {
+        // What the argv tests pass. Falling back for these is what put test
+        // fixtures into the real %TEMP%/mbrc-helper.log.
+        let fallback = scratch("never-a-path");
+        assert_eq!(choose_sink(Path::new("a"), &fallback), None);
+        assert_eq!(choose_sink(Path::new("updates/1.5.0"), &fallback), None);
+        let _ = std::fs::remove_dir_all(&fallback);
+    }
+
+    #[test]
+    fn logging_before_a_sink_is_chosen_is_harmless() {
+        let _exclusive = exclusive();
+        // argv is parsed before --staged is known, and a failure there is worth
+        // printing even though it cannot be filed yet.
+        *sink() = None;
+        line("refusing to continue: --staged is empty");
+    }
+
+    #[test]
+    fn the_timestamp_is_a_real_date() {
+        // 2026-08-22T13:00:00Z
+        let (y, m, d) = civil_from_days(20_687);
+        assert_eq!((y, m, d), (2026, 8, 22));
+        // Epoch day zero, and a leap day.
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+    }
+}

--- a/packages/mbrc-helper/src/main.rs
+++ b/packages/mbrc-helper/src/main.rs
@@ -11,6 +11,7 @@
 //! ```text
 //! mbrc-helper firewall --port <n>
 //! mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>
+//!                    [--relaunch-aumid <aumid>]
 //! ```
 //!
 //! Exit codes are part of the contract with the caller, which reports them to
@@ -24,6 +25,7 @@
 // exercises it on both runners.
 #[cfg_attr(not(windows), allow(dead_code))]
 mod firewall;
+mod log;
 mod update;
 
 use std::collections::BTreeMap;
@@ -68,6 +70,7 @@ mbrc-helper - elevated helper for MusicBee Remote
 USAGE:
     mbrc-helper firewall --port <n>
     mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>
+                       [--relaunch-aumid <aumid>]
     mbrc-helper --version
 
 COMMANDS:
@@ -89,7 +92,7 @@ fn main() -> ExitCode {
     match run(&args) {
         Ok(code) => ExitCode::from(code),
         Err(message) => {
-            eprintln!("mbrc-helper: {message}");
+            log::line(&message);
             ExitCode::from(EXIT_USAGE)
         }
     }
@@ -123,7 +126,13 @@ fn run(args: &[String]) -> Result<u8, String> {
             Ok(run_firewall(port))
         }
         "update" => {
-            let flags = parse_flags(&args[1..], &["pid", "staged", "target", "relaunch"])?;
+            // `relaunch-aumid` is accepted but not required: only a packaged
+            // (Store) MusicBee has one, and an ordinary install is relaunched by
+            // path exactly as before.
+            let flags = parse_flags(
+                &args[1..],
+                &["pid", "staged", "target", "relaunch", "relaunch-aumid"],
+            )?;
             for name in ["pid", "staged", "target", "relaunch"] {
                 require(&flags, name)?;
             }
@@ -137,6 +146,7 @@ fn run(args: &[String]) -> Result<u8, String> {
                 staged: require(&flags, "staged")?,
                 target: require(&flags, "target")?,
                 relaunch: require(&flags, "relaunch")?,
+                relaunch_aumid: flags.get("relaunch-aumid").map(String::as_str),
             }))
         }
         other => Err(format!("unknown command {other:?}\n\n{USAGE}")),
@@ -150,21 +160,30 @@ fn run(args: &[String]) -> Result<u8, String> {
 /// [`EXIT_ROLLED_BACK`] means the install is intact but the update did not
 /// happen, and [`EXIT_ROLLBACK_FAILED`] is the one that needs the user told.
 fn run_update(request: &update::Request<'_>) -> u8 {
+    // Before `plan()`, so that plan()'s own refusals are recorded - one of them
+    // ("--staged cannot be resolved") is how a packaged install fails, and it
+    // used to vanish into a console that does not exist.
+    log::direct_to_storage(std::path::Path::new(request.staged));
+    log::line(&format!(
+        "update requested: pid={} staged={} target={}",
+        request.pid, request.staged, request.target
+    ));
+
     let plan = match update::plan(request) {
         Ok(plan) => plan,
         Err(e) => {
-            eprintln!("mbrc-helper: {e}");
+            log::line(&e.to_string());
             return EXIT_USAGE;
         }
     };
 
     match update::apply(&plan) {
         Ok(applied) => {
-            println!(
-                "mbrc-helper: applied {} ({} file(s))",
+            log::line(&format!(
+                "applied {} ({} file(s))",
                 applied.version,
                 applied.files.len()
-            );
+            ));
             // Only after the swap succeeded: a staged bundle that is still there
             // is one the user can retry with.
             update::clear_staged(&plan);
@@ -172,7 +191,7 @@ fn run_update(request: &update::Request<'_>) -> u8 {
             EXIT_OK
         }
         Err(e) => {
-            eprintln!("mbrc-helper: {e}");
+            log::line(&e.to_string());
             match e {
                 update::Error::Rejected(_) => EXIT_USAGE,
                 update::Error::Verify(_) => EXIT_VERIFY_FAILED,

--- a/packages/mbrc-helper/src/update.rs
+++ b/packages/mbrc-helper/src/update.rs
@@ -47,6 +47,9 @@ pub struct Request<'a> {
     pub staged: &'a str,
     pub target: &'a str,
     pub relaunch: &'a str,
+    /// The Application User Model ID, when MusicBee is a packaged (Store)
+    /// install. `None` for an ordinary install, relaunched by path.
+    pub relaunch_aumid: Option<&'a str>,
 }
 
 /// A request whose paths have been checked and resolved.
@@ -55,7 +58,35 @@ pub struct Plan {
     pub pid: u32,
     pub staged: PathBuf,
     pub target: PathBuf,
-    pub relaunch: PathBuf,
+    pub relaunch: RelaunchTarget,
+}
+
+/// What to start once the update is in place.
+///
+/// A packaged install cannot be started by path: Windows denies executing the
+/// image under `WindowsApps` directly, and the package has to be activated
+/// through its Application User Model ID instead. That is why this is a choice
+/// rather than a path - handing Explorer the executable of a packaged MusicBee
+/// activates nothing while reporting success, which is exactly how an update on
+/// the Store build used to end with MusicBee closed and never reopened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelaunchTarget {
+    /// An ordinary install: the MusicBee executable.
+    Exe(PathBuf),
+    /// A packaged install, named by its AUMID (`<family>!<application>`).
+    Packaged(String),
+}
+
+impl RelaunchTarget {
+    /// What Explorer is handed. It accepts either a path or a
+    /// `shell:AppsFolder\<AUMID>` moniker, which is what lets one code path
+    /// serve both kinds of install.
+    pub fn shell_argument(&self) -> String {
+        match self {
+            Self::Exe(path) => path.display().to_string(),
+            Self::Packaged(aumid) => format!(r"shell:AppsFolder\{aumid}"),
+        }
+    }
 }
 
 /// What an apply did, for the log line.
@@ -119,7 +150,13 @@ type Result<T> = std::result::Result<T, Error>;
 pub fn plan(request: &Request<'_>) -> Result<Plan> {
     let staged = checked_dir(request.staged, "--staged")?;
     let target = checked_dir(request.target, "--target")?;
-    let relaunch = checked_file(request.relaunch, "--relaunch")?;
+    // A packaged install wins when one is named. Its executable exists and would
+    // pass `checked_file`, so validating the path would prove nothing useful -
+    // launching it is what fails.
+    let relaunch = match request.relaunch_aumid {
+        Some(aumid) => RelaunchTarget::Packaged(checked_aumid(aumid)?),
+        None => RelaunchTarget::Exe(checked_file(request.relaunch, "--relaunch")?),
+    };
 
     if staged == target {
         return Err(Error::Rejected(
@@ -201,10 +238,10 @@ fn verify_staged(staged: &Path, keys: &'static [TrustedKey]) -> Result<Bundle> {
 
     let (manifest, key_name) =
         verify_manifest_with(&manifest_bytes, &signature, keys).map_err(Error::Verify)?;
-    println!(
-        "mbrc-helper: manifest for {} signed by {key_name}",
+    crate::log::line(&format!(
+        "manifest for {} signed by {key_name}",
         manifest.version
-    );
+    ));
 
     let mut files = Vec::with_capacity(manifest.files.len());
     for entry in &manifest.files {
@@ -270,11 +307,11 @@ fn back_up(plan: &Plan, bundle: &Bundle) -> Result<Backup> {
     if files.is_empty() {
         return Ok(Backup { dir: None, files });
     }
-    println!(
-        "mbrc-helper: backed up {} file(s) to {}",
+    crate::log::line(&format!(
+        "backed up {} file(s) to {}",
         files.len(),
         root.display()
-    );
+    ));
     Ok(Backup {
         dir: Some(root),
         files,
@@ -291,7 +328,7 @@ fn write_all(plan: &Plan, bundle: &Bundle) -> std::result::Result<(), String> {
             refuse_reparse_point(&path).map_err(|e| e.to_string())?;
         }
         std::fs::write(&path, bytes).map_err(|e| format!("{}: {e}", path.display()))?;
-        println!("mbrc-helper: wrote {}", path.display());
+        crate::log::line(&format!("wrote {}", path.display()));
     }
     Ok(())
 }
@@ -363,7 +400,7 @@ fn prune_backups(plan: &Plan, keep: &str) {
         let path = entry.path();
         if path.is_dir() {
             if let Err(e) = std::fs::remove_dir_all(&path) {
-                eprintln!("mbrc-helper: could not remove {}: {e}", path.display());
+                crate::log::line(&format!("could not remove {}: {e}", path.display()));
             }
         }
     }
@@ -377,16 +414,13 @@ pub fn clear_staged(plan: &Plan) {
     // `<storage>/updates/<version>` -> remove the version directory and the
     // marker beside it, which is what tells the core something is pending.
     if let Err(e) = std::fs::remove_dir_all(&plan.staged) {
-        eprintln!(
-            "mbrc-helper: could not remove {}: {e}",
-            plan.staged.display()
-        );
+        crate::log::line(&format!("could not remove {}: {e}", plan.staged.display()));
     }
     if let Some(updates) = plan.staged.parent() {
         let marker = updates.join("pending.json");
         if marker.exists() {
             if let Err(e) = std::fs::remove_file(&marker) {
-                eprintln!("mbrc-helper: could not remove {}: {e}", marker.display());
+                crate::log::line(&format!("could not remove {}: {e}", marker.display()));
             }
         }
     }
@@ -503,21 +537,70 @@ fn wait_for_exit(_pid: u32, _timeout: Duration) -> bool {
 
 /// Starts MusicBee again after a successful update.
 ///
-/// Launched **through Explorer**, not directly. This process is elevated, and a
-/// child inherits that: starting MusicBee from here would leave it running as
+/// Launched **through Explorer**, not directly. This process may be elevated, and
+/// a child inherits that: starting MusicBee from here would leave it running as
 /// administrator for the rest of the session, writing its settings and cache as
 /// a different user. Explorer runs at the user's own integrity level, so handing
-/// it the path gets MusicBee back at the level it had before.
-pub fn relaunch(exe: &Path) {
-    #[cfg(windows)]
-    {
-        match std::process::Command::new("explorer.exe").arg(exe).spawn() {
-            Ok(_) => println!("mbrc-helper: relaunched {}", exe.display()),
-            Err(e) => eprintln!("mbrc-helper: could not relaunch {}: {e}", exe.display()),
-        }
+/// it the target gets MusicBee back at the level it had before.
+pub fn relaunch(target: &RelaunchTarget) {
+    relaunch_with(target, spawn_via_explorer);
+}
+
+/// The launcher is a parameter so a test can assert what would be started
+/// without starting it - the same seam [`apply_with`] uses for the process wait.
+fn relaunch_with(target: &RelaunchTarget, launch: fn(&str) -> std::io::Result<()>) {
+    let argument = target.shell_argument();
+    match launch(&argument) {
+        Ok(()) => crate::log::line(&format!("relaunched {argument}")),
+        // Recorded but not fatal: the update is installed either way, and the
+        // user can start MusicBee themselves. Note Explorer reports success even
+        // when it activates nothing, so this only catches a failure to start
+        // Explorer at all.
+        Err(e) => crate::log::line(&format!("could not relaunch {argument}: {e}")),
     }
-    #[cfg(not(windows))]
-    let _ = exe;
+}
+
+#[cfg(windows)]
+fn spawn_via_explorer(argument: &str) -> std::io::Result<()> {
+    std::process::Command::new("explorer.exe")
+        .arg(argument)
+        .spawn()
+        .map(|_| ())
+}
+
+#[cfg(not(windows))]
+fn spawn_via_explorer(_argument: &str) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Checks an Application User Model ID before it is handed to Explorer.
+///
+/// The shape is `<package family>!<application>`. Nothing here reaches a shell -
+/// `Command::arg` passes it as a single argument - so this is not about
+/// injection. It is that an elevated process should not act on an argument whose
+/// shape it cannot vouch for, and a value carrying a path separator is not an
+/// AUMID at all.
+fn checked_aumid(raw: &str) -> Result<String> {
+    let aumid = raw.trim();
+    if aumid.is_empty() {
+        return Err(Error::Rejected("--relaunch-aumid is empty".into()));
+    }
+    if aumid.contains(['\\', '/', '"', '\n', '\r']) {
+        return Err(Error::Rejected(format!(
+            "--relaunch-aumid {raw:?} contains a path separator or a quote"
+        )));
+    }
+    let mut parts = aumid.split('!');
+    let (family, app) = (
+        parts.next().unwrap_or_default(),
+        parts.next().unwrap_or_default(),
+    );
+    if family.is_empty() || app.is_empty() || parts.next().is_some() {
+        return Err(Error::Rejected(format!(
+            "--relaunch-aumid {raw:?} is not <family>!<application>"
+        )));
+    }
+    Ok(aumid.to_owned())
 }
 
 #[cfg(test)]
@@ -593,7 +676,7 @@ mod tests {
                 pid: 0,
                 staged: self.staged.clone(),
                 target: self.target.clone(),
-                relaunch: self.root.join("MusicBee.exe"),
+                relaunch: RelaunchTarget::Exe(self.root.join("MusicBee.exe")),
             }
         }
 
@@ -815,6 +898,7 @@ mod tests {
                 staged: &staged,
                 target: bad,
                 relaunch: &relaunch,
+                relaunch_aumid: None,
             };
             assert!(
                 matches!(plan(&request), Err(Error::Rejected(_))),
@@ -829,6 +913,7 @@ mod tests {
             staged: &staged,
             target: &target,
             relaunch: &relaunch,
+            relaunch_aumid: None,
         };
         assert!(plan(&request).is_ok());
     }
@@ -846,8 +931,121 @@ mod tests {
             staged: &fixture.staged.to_string_lossy(),
             target: &inner.to_string_lossy(),
             relaunch: &exe.to_string_lossy(),
+            relaunch_aumid: None,
         };
         assert!(matches!(plan(&request), Err(Error::Rejected(_))));
+    }
+
+    // Captures what would have been launched instead of launching it. A `fn`
+    // pointer rather than a closure so it matches the seam's signature, which is
+    // why the captured value goes through a thread-local.
+    thread_local! {
+        static LAUNCHED: std::cell::RefCell<Vec<String>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    fn record(argument: &str) -> std::io::Result<()> {
+        LAUNCHED.with(|l| l.borrow_mut().push(argument.to_owned()));
+        Ok(())
+    }
+
+    fn refuse(_argument: &str) -> std::io::Result<()> {
+        Err(std::io::Error::other("explorer is not available"))
+    }
+
+    #[test]
+    fn a_packaged_install_is_relaunched_through_its_aumid() {
+        // The whole point of the AUMID: handing Explorer the executable of a
+        // packaged MusicBee activates nothing.
+        LAUNCHED.with(|l| l.borrow_mut().clear());
+        let target =
+            RelaunchTarget::Packaged("50072StevenMayall.MusicBee_kcr266et74avj!App".into());
+
+        relaunch_with(&target, record);
+
+        LAUNCHED.with(|l| {
+            assert_eq!(
+                l.borrow().as_slice(),
+                [r"shell:AppsFolder\50072StevenMayall.MusicBee_kcr266et74avj!App"]
+            );
+        });
+    }
+
+    #[test]
+    fn an_ordinary_install_is_still_relaunched_by_path() {
+        LAUNCHED.with(|l| l.borrow_mut().clear());
+        let target = RelaunchTarget::Exe(PathBuf::from(r"C:\Program Files\MusicBee\MusicBee.exe"));
+
+        relaunch_with(&target, record);
+
+        LAUNCHED.with(|l| {
+            assert_eq!(
+                l.borrow().as_slice(),
+                [r"C:\Program Files\MusicBee\MusicBee.exe"]
+            );
+        });
+    }
+
+    #[test]
+    fn a_relaunch_that_cannot_start_is_survivable() {
+        // The update is already installed by this point; failing to start
+        // MusicBee is worth recording, not worth panicking over.
+        relaunch_with(&RelaunchTarget::Exe(PathBuf::from(r"C:\nope.exe")), refuse);
+    }
+
+    #[test]
+    fn an_aumid_that_is_not_one_is_refused() {
+        // An elevated process should not act on an argument whose shape it
+        // cannot vouch for. A path separator is the giveaway.
+        for bad in [
+            "",
+            "   ",
+            "no-bang",
+            "!missing-family",
+            "missing-app!",
+            "two!bangs!here",
+            r"family\..\..\evil!App",
+            "family/App!App",
+            "family\"quote!App",
+        ] {
+            assert!(
+                matches!(checked_aumid(bad), Err(Error::Rejected(_))),
+                "{bad:?} was accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn a_real_aumid_is_accepted_and_trimmed() {
+        let aumid = checked_aumid("  50072StevenMayall.MusicBee_kcr266et74avj!MusicBeePackage  ")
+            .expect("a well-formed AUMID");
+        assert_eq!(
+            aumid,
+            "50072StevenMayall.MusicBee_kcr266et74avj!MusicBeePackage"
+        );
+    }
+
+    #[test]
+    fn an_aumid_takes_precedence_over_the_executable() {
+        // Both are passed - the executable exists and would validate - and the
+        // packaged form has to win, because the path is the one that cannot work.
+        let fixture = Fixture::new("aumid-wins");
+        let exe = fixture.root.join("MusicBee.exe");
+        std::fs::write(&exe, b"stub").unwrap();
+        let target = fixture.root.join("plugins");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let request = Request {
+            pid: 1,
+            staged: &fixture.staged.to_string_lossy(),
+            target: &target.to_string_lossy(),
+            relaunch: &exe.to_string_lossy(),
+            relaunch_aumid: Some("Family_abc!App"),
+        };
+        let plan = plan(&request).expect("plan");
+        assert_eq!(
+            plan.relaunch,
+            RelaunchTarget::Packaged("Family_abc!App".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
> **Read this first.** One of the three changes here is a **candidate fix that could not be verified**, and there is evidence it may be wrong. It is called out under *Unverified* below and in a doc comment on `spawn_direct`. Shipping it deliberately, because the change that *does* matter — the helper log — is what will tell us whether it worked.

## The problem

Auto-update does not work on the Microsoft Store build of MusicBee. It stages the bundle, closes MusicBee, silently does nothing, and never reopens the app. The user is left with a closed MusicBee, an unchanged plugin, and a `pending.json` that offers the same broken install again on every start.

Three separate faults, all confirmed on a real Store install.

## 1. The helper had no voice — and this is the change that matters

Its only diagnostics were `println!`/`eprintln!`, and it is launched with no console. Both faults below therefore failed in **total silence**: the exit code was the only signal, and nothing was left running to read it. That is why diagnosing this took an afternoon of filesystem forensics.

Everything the helper prints now also appends to `mbrc-helper.log` beside the plugin's other logs, falling back to `%TEMP%` when the storage directory cannot be written — which is precisely the outside-the-container case this exists to expose. The diagnostics bundle collects it.

Not a logging framework: a short-lived process writing a handful of lines does not need a dependency, a filter and a level system wrapped around `writeln!`.

## 2. A packaged MusicBee cannot be relaunched by path

`--relaunch` is `current_exe()`, i.e. `WindowsApps\…\MusicBee.exe`. Windows denies executing that directly:

```
Start-Process …\WindowsApps\…\MusicBee.exe  →  Access is denied.
```

Explorer, handed that path, activates nothing and reports success. The core now derives the AUMID and passes `--relaunch-aumid`; the helper starts `shell:AppsFolder\<AUMID>` instead — the form proven to work.

A **new flag** rather than overloading `--relaunch`, because that one is validated as an existing absolute file and a moniker is none of those; overloading it would trip the validation that makes the helper safe. **Derived, never accepted from the host**, so the module's rule — nothing is taken from the caller, so there is nothing to tamper with — still holds, and `mbrc_apply_staged_update` keeps its zero-argument signature.

## 3. The helper starts outside the package container — the unverified one

`ShellExecuteExW` hands the launch to the shell, and MSIX virtualizes `%APPDATA%`, so the helper's argv resolves to nothing. Reproduced exactly, by running the staged helper by hand with the arguments the core passed:

```
mbrc-helper: refusing to continue: --staged "…\AppData\Roaming\MusicBee\mb_remote\updates\1.5.0-beta.2"
  cannot be resolved: The system cannot find the path specified. (os error 3)
```

It refuses rather than guessing, which is why nothing was ever damaged: `%APPDATA%\MusicBee` was never created and the installed files were untouched.

It is now started as an **ordinary child process** when no elevation is needed. The `runas` verb stays for when it is — `CreateProcess` cannot elevate. The verified-helper handle is unaffected: it denies write and delete while permitting read, and the loader's `FILE_EXECUTE` counts as read whichever way the process is created.

### Unverified, and the risk

**This cannot be tested from a working tree.** `elevate::launch` deliberately runs the *staged* helper, never the installed one, so only a release built from this code exercises it. Testing against published beta.2 runs beta.2's *old* helper. The first hop that can validate this is **beta.3 → beta.4**.

**And there is evidence against it.** A packaged MusicBee runs inside a job object:

```
pid=28756  IsProcessInJob=True
```

A `CreateProcess` child joins its parent's job. If that job terminates its processes when the app exits, the helper dies at exactly the moment it stops waiting and starts work — which would make this *worse* than what it replaces. `CREATE_BREAKAWAY_FROM_JOB` is the escape hatch, but only if the job permits breakaway.

If it proves wrong, the fallback is to keep the shell launch and have the core resolve the real container paths (`GetFinalPathNameByHandleW`) before passing them, which depends on neither container inheritance nor job breakaway. All of this is recorded in a doc comment on `spawn_direct` rather than only here.

## What beta.3 will tell us

Even if fix 3 is wrong, beta.3 is worth cutting: its helper **logs**. A Store update from beta.2 → beta.3 runs beta.2's old core (old launch) with beta.3's new helper, so the failure becomes visible in `%TEMP%\mbrc-helper.log` instead of silent — and that log says which of the two explanations is right.

Note Store users on beta.1/beta.2 need one manual install regardless, for the version-stamp reason in #176.

## Testing

`relaunch()` had no test and no seam — the `explorer.exe` command was hardcoded. Extracted a launcher parameter shaped like the existing injected `wait` on `apply_with`, so a test asserts the command line without launching anything.

New tests: an AUMID relaunch issues `shell:AppsFolder\<aumid>` and an exe relaunch still issues the path; a malformed AUMID is refused (empty, no `!`, empty halves, two `!`, path separators, quotes); the AUMID wins over an executable that would itself validate; a relaunch that cannot start is survivable; the log writes beside the other logs, falls back when the storage directory is unreachable, and is harmless before a sink is chosen.

**203 core + 47 helper tests pass**; `cargo fmt`, `clippy --workspace --all-targets -D warnings` clean. `docs/updates.md` updated for the new flag, the launch mechanism and the log.

One defect found and fixed while writing these: the helper tests were writing fixtures into the **real** `%TEMP%\mbrc-helper.log` — a file users are asked to read and the diagnostics bundle collects. The fallback now applies only to a storage directory that exists and cannot be written, not to arguments that were never paths.
