### PR TITLE
fix(plugin): read now-playing list tags by index, not by url

### DIFF
--- a/packages/plugin/Providers/TrackDataProvider.cs
+++ b/packages/plugin/Providers/TrackDataProvider.cs
@@ -224,7 +224,13 @@ namespace MusicBeePlugin.Providers
 
                 if (position > offset)
                 {
-                    var success = _api.Library_GetFileTags(trackPath, NowPlayingFields, out var results);
+                    // Read by INDEX, not by URL. Every virtual track of a
+                    // single-file .cue album reports the same container URL, so a
+                    // URL-keyed read returns the container's (empty) file-level
+                    // tags for all of them - which is what made such albums show
+                    // N rows of "Unknown Artist" (#87). The index-keyed call
+                    // returns the per-subsong tags MusicBee already has.
+                    var success = _api.NowPlayingList_GetFileTags(itemIndex, NowPlayingFields, out var results);
                     // Raw values; the empty title -> file name fallback lives in the
                     // Rust V4 wire codec now. position is the actual list index.
                     yield return new NowPlayingListTrack
@@ -248,34 +254,41 @@ namespace MusicBeePlugin.Providers
             if (!_api.NowPlayingList_QueryFiles(null))
                 yield break;
 
-            // Advance the list cursor sequentially, but read tags ONLY inside the
-            // window [offset, offset+limit). Skipped items still pull the (cheap)
-            // path string to move the cursor; the expensive tag read is bounded to
-            // the page. Ordering is sequential (Android variant).
+            // Walk the list by INDEX rather than with the query cursor, so the
+            // path and the tags for a row come from the same index and can never
+            // be attributed to different tracks. That matters because the tags are
+            // now read by index too: every virtual track of a single-file .cue
+            // album reports the same container URL, so the old URL-keyed read
+            // returned the container's (empty) file-level tags for all of them -
+            // N rows of "Unknown Artist" (#87).
+            //
+            // Skipped items cost nothing now: the window can be entered directly
+            // instead of pulling a path per item to advance a cursor. Ordering is
+            // sequential (Android variant), unchanged - `GetListFileUrl` walks the
+            // list in the same storage order the cursor did.
             var windowEnd = limit > 0 ? (long)offset + limit : long.MaxValue;
-            var position = 1;
+            var index = offset > 0 ? offset : 0;
+            var position = index + 1;
             while (position <= windowEnd)
             {
-                var trackPath = _api.NowPlayingList_QueryGetNextFile();
+                var trackPath = _api.NowPlayingList_GetListFileUrl(index);
                 if (string.IsNullOrEmpty(trackPath))
                     break;
 
-                if (position > offset)
+                var success = _api.NowPlayingList_GetFileTags(index, NowPlayingFields, out var results);
+                // Raw values; the V4 empty-artist -> "Unknown Artist" and empty
+                // title -> file name fallbacks live in the Rust V4 wire codec.
+                yield return new NowPlayingListTrack
                 {
-                    var success = _api.Library_GetFileTags(trackPath, NowPlayingFields, out var results);
-                    // Raw values; the V4 empty-artist -> "Unknown Artist" and empty
-                    // title -> file name fallbacks live in the Rust V4 wire codec.
-                    yield return new NowPlayingListTrack
-                    {
-                        artist = SafeGetResult(success, results, 0),
-                        album = SafeGetResult(success, results, 1),
-                        album_artist = SafeGetResult(success, results, 2),
-                        title = SafeGetResult(success, results, 3),
-                        position = position,
-                        path = trackPath
-                    };
-                }
+                    artist = SafeGetResult(success, results, 0),
+                    album = SafeGetResult(success, results, 1),
+                    album_artist = SafeGetResult(success, results, 2),
+                    title = SafeGetResult(success, results, 3),
+                    position = position,
+                    path = trackPath
+                };
 
+                index++;
                 position++;
             }
         }


### PR DESCRIPTION
Closes part of #87.

## The symptom

A single-file + `.cue` album showed in the now-playing list as N rows of **"Unknown Artist"** and a file name.

## Why

Every virtual track of such an album reports the **same container URL**, so the URL-keyed `Library_GetFileTags(trackPath, …)` returned the container's file-level tags — empty — for every subsong. MusicBee had the correct per-subsong tags the whole time; the plugin was asking the wrong way. `NowPlayingList_GetFileTags(index, …)` returns them.

## The change

Both list methods now read by index.

The **ordered (iOS)** variant already had the index in hand (`itemIndex`) — a direct swap.

The **sequential (Android)** one walked a query cursor that yields no index. Rather than compute one from a counter and risk pairing a path from the cursor with tags from a different track, it now walks `NowPlayingList_GetListFileUrl(index)` so the path and the tags for a row come from the same index by construction. Entering the window directly also drops the per-item path pull that existed only to advance the cursor.

## Verified live

Against the repro fixture (`tools/cue-fixture/make_cue_album.py`) and a real 15751-track library, over the wire with `mbrc send`:

| case | result |
| --- | --- |
| cue album, Android page | four rows, `Tone A (220 Hz)` … `Tone D (550 Hz)`, correct artist — previously four identical "Unknown Artist" rows |
| cue album, iOS ordered | correct per-subsong tags, with album and album artist |
| 15751-track library | correct artists, titles, distinct paths |
| `offset:100, limit:3` | positions 101–103, correctly aligned |

The offset case is the one that matters for the Android rewrite, since entering the window directly is the part that could have misaligned.

## What this does not fix

The API cannot. All subsongs still report the container path, so play-by-index still starts the first subsong, and metadata writes (love/ban/rating) still cannot target a subsong — there is no index-keyed write anywhere in the MusicBee API. Both remain on #87, along with two experiments: a duration-based detector to refuse ambiguous writes silently, and a seek trick that may unblock subsong selection without parsing cue files at all.