### PR TITLE
fix(hooks): refuse a push whose files are dirty in the tree

### DIFF
--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -13,7 +13,7 @@ One command per clone. Until it is run, no hooks fire.
 | --- | --- | --- |
 | `commit-msg` | Conventional Commits, matching `@commitlint/config-conventional` | instant |
 | `pre-commit` | `cargo fmt --check`, root workspace **and** `tools/api-debugger/src-tauri` | ~2s |
-| `pre-push` | clippy (`-D warnings`), the test suites, generated-FFI-bindings drift, `dotnet format --verify-no-changes` | ~2-4 min |
+| `pre-push` | working tree vs pushed range, clippy (`-D warnings`), the test suites, generated-FFI-bindings drift, `dotnet format --verify-no-changes` | ~2-4 min |
 
 The split is the point. A pre-commit hook that takes a minute gets bypassed, and
 a bypassed hook is worse than none because it still looks like a safety net. So
@@ -67,3 +67,13 @@ They run on **your** platform. CI also builds on ubuntu, and a path literal or a
 `cfg` that behaves differently there will pass here and fail in CI - that has
 already happened once. These hooks shorten the loop on the failures that are
 reproducible locally; they are not a reason to stop reading CI.
+
+They also test your **working tree**, not the commits being pushed. Normally the
+two are identical; when they are not, a green hook can wave through a commit that
+does not compile - a fix left uncommitted in the tree while the commit that
+needed it was amended and pushed, and the hook dutifully tested the fixed tree.
+
+`pre-push` therefore refuses when a file with uncommitted changes is **also**
+touched by the commits being pushed, and only then: unrelated work in progress is
+normal and gets a one-line note instead. Commit or stash the overlap, or use
+`MBRC_SKIP_HOOKS=1`.

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -12,6 +12,9 @@
 #                     there
 #   dotnet format   - a new .cs file with the wrong encoding fails CI on CHARSET,
 #                     which is invisible locally until you look
+#   tree vs range   - these checks test the working tree; if a pushed file also
+#                     has uncommitted changes they describe something other than
+#                     what is being pushed (see below)
 #
 # What this CANNOT catch: platform-specific breakage. These hooks run on Windows,
 # and CI also runs ubuntu - a path literal or a cfg that behaves differently there
@@ -28,6 +31,58 @@ fi
 
 root=$(git rev-parse --show-toplevel)
 cd "$root"
+
+# --- what is tested vs what is pushed --------------------------------------
+# Everything below runs against the WORKING TREE, not against the commits being
+# pushed. Usually the two agree. When they do not, a green hook can wave through
+# a commit that does not even compile - which has happened here: a fix sat
+# uncommitted in the tree while the commit that needed it was amended and
+# pushed, and the hook happily tested the fixed tree.
+#
+# Failing on any dirty file would be too blunt, since unrelated work in progress
+# is normal. The rule is narrow instead: refuse only when a file with
+# uncommitted changes is ALSO touched by the commits being pushed. That is
+# exactly the case where the tree and the range differ in a way these checks
+# cannot see. Anything else is only worth a warning.
+refs=$(cat)
+
+pushed_files() {
+    printf '%s\n' "$refs" | while read -r _local_ref local_sha _remote_ref remote_sha; do
+        [ -z "$local_sha" ] && continue
+        # An all-zero local sha is a branch deletion: nothing is being pushed.
+        case "$local_sha" in *[!0]*) : ;; *) continue ;; esac
+        case "$remote_sha" in
+            # A new branch (all-zero remote sha) has no remote side to diff
+            # against, so compare with the upstream default branch instead.
+            *[!0]*) base="$remote_sha" ;;
+            *) base=$(git merge-base "$local_sha" origin/HEAD 2>/dev/null) || base= ;;
+        esac
+        if [ -n "$base" ]; then
+            git diff --name-only "$base" "$local_sha" 2>/dev/null
+        else
+            git show --pretty=format: --name-only "$local_sha" 2>/dev/null
+        fi
+    done
+}
+
+dirty=$(git diff --name-only HEAD --)
+if [ -n "$dirty" ]; then
+    tmp_pushed=$(mktemp)
+    trap 'rm -f "$tmp_pushed"' EXIT
+    pushed_files | sort -u > "$tmp_pushed"
+    overlap=$(printf '%s\n' "$dirty" | sort -u | grep -Fxf "$tmp_pushed" || true)
+    if [ -n "$overlap" ]; then
+        echo >&2
+        echo "  Uncommitted changes to files this push touches:" >&2
+        printf '    %s\n' $overlap >&2
+        echo >&2
+        echo "  The checks below test your working tree, so they would describe" >&2
+        echo "  code that is not what you are pushing. Commit (or stash) these" >&2
+        echo "  first, or re-run with MBRC_SKIP_HOOKS=1." >&2
+        exit 1
+    fi
+    echo "pre-push: note - working tree is dirty, but not in the pushed files"
+fi
 
 target="i686-pc-windows-msvc"
 fail() { echo; echo "  $1" >&2; exit 1; }


### PR DESCRIPTION
## The gap

`pre-push` runs clippy, the test suites, the bindings-drift check and
`dotnet format` against the **working tree** - not against the commits being
pushed. Usually those are the same thing. When they are not, the hook reports on
code that is not what lands.

It happened while rebasing #137: a fix to `mbrc-wire/src/lib.rs` was sitting
uncommitted in the tree while the commit that needed it was amended and pushed.
The hook tested the fixed tree, went green, and passed a commit that would not
compile. Nothing downstream noticed either, because the branch was force-pushed
again a minute later for an unrelated reason.

## The rule

Refusing on any dirty file would be too blunt - having unrelated work in progress
while pushing a branch is normal. So the check is narrow: **refuse only when a
file with uncommitted changes is also touched by the commits being pushed.** That
is precisely the case where the tree and the range differ in a way the checks
below cannot see. Everything else gets a one-line note.

```
  Uncommitted changes to files this push touches:
    packages/mbrc-wire/src/lib.rs

  The checks below test your working tree, so they would describe
  code that is not what you are pushing. Commit (or stash) these
  first, or re-run with MBRC_SKIP_HOOKS=1.
```

The pushed range comes from the refs git feeds the hook on stdin:

| case | range |
|---|---|
| existing branch | `<remote sha>..<local sha>` |
| new branch (all-zero remote sha) | merge-base with `origin/HEAD`..local |
| branch deletion (all-zero local sha) | contributes nothing |

It runs before the slow checks, so the failure is immediate.

## Verified

Exercised by hand against this repo, feeding the hook the stdin refs git would:

- a dirty file **inside** the pushed range -> refused, naming the file;
- a dirty file **outside** it -> `note - working tree is dirty, but not in the pushed files`, then proceeds;
- new branch (all-zero remote sha) -> range resolved via `origin/HEAD`, refusal still fires;
- branch deletion (all-zero local sha) -> contributes no files, no false refusal.

`sh -n` clean; this push itself went through the modified hook.
