### PR TITLE
fix(update): keep the update helper inside the package container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,11 @@ TestResults/
 
 # Release signing keys: private halves must never be committed.
 mbrc-release-*.key
+
+# Local update-testing keys. `mbrc-release/build.rs` compiles every keys/*.pub
+# into TRUSTED_KEYS, so dropping one here makes a LOCAL build trust a locally
+# signed bundle - which is what lets tools/stage-local-update.ps1 exercise the
+# apply path without cutting a release. It must never reach a release: a build
+# carrying it trusts any bundle writable in the staging directory, and the apply
+# runs elevated. CI builds from a clean checkout, so ignoring it is the boundary.
+packages/mbrc-release/keys/dev*.pub

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -83,6 +83,14 @@ windows-sys = { version = "=0.61.2", features = [
     # an ordinary one. A packaged app cannot be started by path, so the update
     # helper has to be told the identity to activate instead.
     "Win32_Storage_Packaging_Appx",
+    # CreateProcessW with a proc-thread attribute list: a packaged app's children
+    # leave the package container by default, so the update helper has to be
+    # started with PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE to see the
+    # same redirected paths the core does.
+    "Win32_System_Threading",
+    # PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE lives here, not beside the
+    # attribute constant it is a value for.
+    "Win32_System_WindowsProgramming",
 ] }
 
 [build-dependencies]

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -404,7 +404,14 @@ fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
                     tracing::error!(%status, "the update helper exited immediately");
                     UpdateLaunch::Failed
                 }
-                _ => UpdateLaunch::Launched,
+                Ok(None) => UpdateLaunch::Launched,
+                // Not knowing is not the same as knowing it is fine, but the
+                // helper was started and the alternative is refusing an update
+                // that is probably running. Say so and go on.
+                Err(e) => {
+                    tracing::warn!(error = %e, "could not confirm the update helper is still running");
+                    UpdateLaunch::Launched
+                }
             }
         }
         Err(e) => {
@@ -423,6 +430,7 @@ fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
 /// bundle that does not verify - happens in milliseconds, while a healthy helper
 /// then sits waiting for MusicBee for two minutes. A short pause separates the
 /// two cleanly, and it costs a keypress that was about to close the app anyway.
+#[cfg(windows)]
 const SETTLE: std::time::Duration = std::time::Duration::from_millis(750);
 
 /// Starts the helper as a child that stays *inside* this packaged app's
@@ -441,12 +449,11 @@ const SETTLE: std::time::Duration = std::time::Duration::from_millis(750);
 ///   in place.
 #[cfg(windows)]
 fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
-    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, WAIT_OBJECT_0};
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
     use windows_sys::Win32::System::Threading::{
-        CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
-        InitializeProcThreadAttributeList, UpdateProcThreadAttribute, WaitForSingleObject,
-        EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
-        PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, STARTUPINFOEXW,
+        CreateProcessW, DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
+        UpdateProcThreadAttribute, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST,
+        PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, STARTUPINFOEXW,
     };
     use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE;
 
@@ -532,15 +539,7 @@ fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     // helper outlives us deliberately, so the handles are closed rather than
     // held until process exit.
     // SAFETY: both handles come from a successful CreateProcessW.
-    let exited = unsafe { WaitForSingleObject(process.hProcess, SETTLE.as_millis() as u32) };
-    let mut status: u32 = 0;
-    let status = if exited == WAIT_OBJECT_0 {
-        // SAFETY: the handle is live until CloseHandle below.
-        unsafe { GetExitCodeProcess(process.hProcess, &mut status) };
-        Some(status)
-    } else {
-        None
-    };
+    let status = settled_exit_code(process.hProcess);
     // SAFETY: both handles come from a successful CreateProcessW.
     unsafe {
         CloseHandle(process.hThread);
@@ -561,10 +560,37 @@ fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     UpdateLaunch::Launched
 }
 
+/// Watches a just-started helper for [`SETTLE`] and reports its exit code if it
+/// has already finished.
+///
+/// `None` means "still running, or could not be determined". Only an observed
+/// exit is a reason to refuse: `WAIT_FAILED` and a `GetExitCodeProcess` that
+/// does not succeed leave us not knowing, and turning not-knowing into a refusal
+/// would strand an update that is very likely applying.
+#[cfg(windows)]
+fn settled_exit_code(process: windows_sys::Win32::Foundation::HANDLE) -> Option<u32> {
+    use windows_sys::Win32::Foundation::WAIT_OBJECT_0;
+    use windows_sys::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject};
+
+    // SAFETY: `process` is a live process handle owned by the caller.
+    if unsafe { WaitForSingleObject(process, SETTLE.as_millis() as u32) } != WAIT_OBJECT_0 {
+        return None;
+    }
+    let mut status: u32 = 0;
+    // SAFETY: same handle, still live; `status` is a plain out-parameter.
+    if unsafe { GetExitCodeProcess(process, &mut status) } == 0 {
+        tracing::warn!("the update helper exited but its status could not be read");
+        return None;
+    }
+    Some(status)
+}
+
 #[cfg(windows)]
 fn spawn_elevated(exe: &Path, arguments: &[String]) -> UpdateLaunch {
-    use windows_sys::Win32::Foundation::{GetLastError, ERROR_CANCELLED};
-    use windows_sys::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SHELLEXECUTEINFOW};
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_CANCELLED};
+    use windows_sys::Win32::UI::Shell::{
+        ShellExecuteExW, SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW,
+    };
     use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
     let verb = wide("runas");
@@ -575,7 +601,9 @@ fn spawn_elevated(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     info.cbSize = size_of::<SHELLEXECUTEINFOW>() as u32;
     // NOASYNC because this process is about to be asked to exit: the shell must
     // finish launching before we can go away.
-    info.fMask = SEE_MASK_NOASYNC;
+    // NOCLOSEPROCESS so `hProcess` comes back and the launch can be confirmed
+    // the same way the direct paths confirm theirs; the handle is ours to close.
+    info.fMask = SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS;
     info.lpVerb = verb.as_ptr();
     info.lpFile = file.as_ptr();
     info.lpParameters = parameters.as_ptr();
@@ -585,6 +613,24 @@ fn spawn_elevated(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     // outlives the call, and `cbSize` is the struct's real size.
     let ok = unsafe { ShellExecuteExW(&mut info) };
     if ok != 0 {
+        // `SEE_MASK_NOASYNC` waits for the shell to *start* the helper, not for
+        // it to survive - so without this an instant refusal still closes
+        // MusicBee into silence, which is the whole failure `SETTLE` exists to
+        // stop. The handle can still be null if the shell reused an existing
+        // process; nothing to watch then, and nothing to close.
+        if !info.hProcess.is_null() {
+            let status = settled_exit_code(info.hProcess);
+            // SAFETY: the handle came from a successful ShellExecuteExW with
+            // NOCLOSEPROCESS, so closing it is this function's job.
+            unsafe { CloseHandle(info.hProcess) };
+            if let Some(status) = status {
+                tracing::error!(
+                    status,
+                    "the elevated update helper exited immediately; see mbrc-helper.log"
+                );
+                return UpdateLaunch::Failed;
+            }
+        }
         return UpdateLaunch::Launched;
     }
 

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -366,23 +366,36 @@ fn spawn(exe: &Path, arguments: &[String], elevate: bool) -> UpdateLaunch {
 /// between the hash check and this call. Rust opens files non-inheritable, so the
 /// handle is not passed to the child either.
 ///
-/// # Unverified, and one known risk
+/// # Why a packaged parent needs more than `Command::spawn`
 ///
-/// A packaged MusicBee runs inside a **job object** (confirmed with
-/// `IsProcessInJob`), and a `CreateProcess` child joins its parent's job. If that
-/// job terminates its processes when the app exits, this helper dies at exactly
-/// the moment it stops waiting and starts work - which would make this change
-/// worse than what it replaces, not better. `CREATE_BREAKAWAY_FROM_JOB` is the
-/// escape hatch, but only if the job permits breakaway.
+/// A `CreateProcess` child of a packaged (MSIX) app does **not** inherit the
+/// package container by default, and that is documented behaviour rather than an
+/// anomaly: `PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY` defaults to
+/// `PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_ENABLE_PROCESS_TREE`, which puts
+/// children *outside* the desktop app runtime environment. The helper then sees
+/// the un-redirected `%APPDATA%`, where nothing we staged exists, and correctly
+/// refuses to act on paths it cannot resolve.
 ///
-/// Neither the container inheritance this relies on nor the job behaviour above
-/// has been observed on a real Store install: the helper that runs is always the
-/// *staged* one, so only a release built from this code can exercise it. The
-/// first hop that can is beta.3 -> beta.4. If it turns out wrong, the fallback is
-/// to keep the shell launch and have the core resolve the real container paths
-/// (`GetFinalPathNameByHandleW`) before passing them, which depends on neither.
+/// Observed twice on a real Store install, both times as
+/// `--staged "..." cannot be resolved: The system cannot find the path
+/// specified. (os error 3)`. The job object a packaged app runs in was
+/// suspected first and is ruled out: the helper ran, logged, and exited of its
+/// own accord.
+///
+/// `PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE` reverses that for the
+/// child being created (not its descendants, which is all we need). The child
+/// then sees exactly what the core sees, so the existing argv needs no path
+/// translation - which is the reason this is preferable to resolving container
+/// paths with `GetFinalPathNameByHandleW` before passing them: that returns
+/// `\?\`-prefixed paths, and the helper's `checked_path` rejects a leading
+/// double backslash as a network path.
 #[cfg(windows)]
 fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
+    // Only a packaged parent has the problem, and the attribute is only
+    // meaningful there. An ordinary install keeps the plain, well-trodden path.
+    if current_aumid().is_some() {
+        return spawn_in_container(exe, arguments);
+    }
     match std::process::Command::new(exe).args(arguments).spawn() {
         Ok(_) => UpdateLaunch::Launched,
         Err(e) => {
@@ -390,6 +403,122 @@ fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
             UpdateLaunch::Failed
         }
     }
+}
+
+/// Starts the helper as a child that stays *inside* this packaged app's
+/// container.
+///
+/// `std::process::Command` cannot set proc-thread attributes, so this is raw
+/// `CreateProcessW` with an attribute list. The dance is fiddly in three places
+/// and each one is load-bearing:
+///
+/// - the attribute list is sized by a first, deliberately-failing
+///   `InitializeProcThreadAttributeList` call, then allocated and initialized;
+/// - `policy` must outlive the attribute list, because `UpdateProcThreadAttribute`
+///   stores the pointer rather than copying the value - a temporary here would
+///   be a dangling read at `CreateProcessW`;
+/// - `lpCommandLine` must be a writable buffer: `CreateProcessW` may modify it
+///   in place.
+#[cfg(windows)]
+fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
+    use windows_sys::Win32::System::Threading::{
+        CreateProcessW, DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
+        UpdateProcThreadAttribute, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST,
+        PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, STARTUPINFOEXW,
+    };
+    use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE;
+
+    let mut command_line = wide(&format!("\"{}\" {}", exe.display(), quote(arguments)));
+
+    // First call fails with ERROR_INSUFFICIENT_BUFFER by design and reports the
+    // size; one attribute is all this ever sets.
+    let mut size: usize = 0;
+    // SAFETY: the documented probe - a null list with the size out-parameter.
+    unsafe { InitializeProcThreadAttributeList(std::ptr::null_mut(), 1, 0, &mut size) };
+    if size == 0 {
+        tracing::error!("could not size the process attribute list");
+        return UpdateLaunch::Failed;
+    }
+    let mut buffer = vec![0u8; size];
+    let list = buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+    // SAFETY: `buffer` is `size` bytes, which is what the probe asked for.
+    if unsafe { InitializeProcThreadAttributeList(list, 1, 0, &mut size) } == 0 {
+        tracing::error!(
+            code = unsafe { GetLastError() },
+            "could not initialize the process attribute list"
+        );
+        return UpdateLaunch::Failed;
+    }
+
+    // Must outlive `list`: the attribute stores this pointer, it does not copy.
+    let policy: u32 = PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE;
+    // SAFETY: `list` is initialized above, and `policy` is a DWORD living until
+    // after `DeleteProcThreadAttributeList` below.
+    let updated = unsafe {
+        UpdateProcThreadAttribute(
+            list,
+            0,
+            PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY as usize,
+            &policy as *const u32 as *const std::ffi::c_void,
+            size_of::<u32>(),
+            std::ptr::null_mut(),
+            std::ptr::null(),
+        )
+    };
+    if updated == 0 {
+        let code = unsafe { GetLastError() };
+        // SAFETY: `list` was initialized.
+        unsafe { DeleteProcThreadAttributeList(list) };
+        tracing::error!(code, "could not set the desktop-app breakaway policy");
+        return UpdateLaunch::Failed;
+    }
+
+    let mut startup: STARTUPINFOEXW = unsafe { std::mem::zeroed() };
+    startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+    startup.lpAttributeList = list;
+    let mut process: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+
+    // SAFETY: `command_line` is a writable null-terminated wide buffer that
+    // outlives the call, and the startup info carries its real size plus the
+    // attribute list initialized above.
+    let started = unsafe {
+        CreateProcessW(
+            std::ptr::null(),
+            command_line.as_mut_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            EXTENDED_STARTUPINFO_PRESENT,
+            std::ptr::null(),
+            std::ptr::null(),
+            &startup.StartupInfo,
+            &mut process,
+        )
+    };
+    let code = unsafe { GetLastError() };
+    // SAFETY: `list` was initialized and is no longer referenced by anything.
+    unsafe { DeleteProcThreadAttributeList(list) };
+
+    if started == 0 {
+        tracing::error!(
+            code,
+            "could not start the update helper inside the container"
+        );
+        return UpdateLaunch::Failed;
+    }
+    // Nothing waits on the helper - it outlives us deliberately - so both
+    // handles are closed straight away rather than leaked until process exit.
+    // SAFETY: both handles come from a successful CreateProcessW.
+    unsafe {
+        CloseHandle(process.hThread);
+        CloseHandle(process.hProcess);
+    }
+    tracing::info!(
+        pid = process.dwProcessId,
+        "started the update helper inside the package container"
+    );
+    UpdateLaunch::Launched
 }
 
 #[cfg(windows)]

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -397,13 +397,33 @@ fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
         return spawn_in_container(exe, arguments);
     }
     match std::process::Command::new(exe).args(arguments).spawn() {
-        Ok(_) => UpdateLaunch::Launched,
+        Ok(mut child) => {
+            std::thread::sleep(SETTLE);
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    tracing::error!(%status, "the update helper exited immediately");
+                    UpdateLaunch::Failed
+                }
+                _ => UpdateLaunch::Launched,
+            }
+        }
         Err(e) => {
             tracing::error!(error = %e, "could not start the update helper");
             UpdateLaunch::Failed
         }
     }
 }
+
+/// How long to watch a just-started helper before believing it.
+///
+/// `Launched` makes the panel close MusicBee, so reporting it for a helper that
+/// has already refused produces the worst outcome available: MusicBee shuts, the
+/// update does not happen, and there is no window left to say so. Every refusal
+/// the helper can reach before it starts waiting - a path it cannot resolve, a
+/// bundle that does not verify - happens in milliseconds, while a healthy helper
+/// then sits waiting for MusicBee for two minutes. A short pause separates the
+/// two cleanly, and it costs a keypress that was about to close the app anyway.
+const SETTLE: std::time::Duration = std::time::Duration::from_millis(750);
 
 /// Starts the helper as a child that stays *inside* this packaged app's
 /// container.
@@ -421,11 +441,12 @@ fn spawn_direct(exe: &Path, arguments: &[String]) -> UpdateLaunch {
 ///   in place.
 #[cfg(windows)]
 fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
-    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, WAIT_OBJECT_0};
     use windows_sys::Win32::System::Threading::{
-        CreateProcessW, DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
-        UpdateProcThreadAttribute, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST,
-        PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, STARTUPINFOEXW,
+        CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
+        InitializeProcThreadAttributeList, UpdateProcThreadAttribute, WaitForSingleObject,
+        EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
+        PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, STARTUPINFOEXW,
     };
     use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE;
 
@@ -507,12 +528,31 @@ fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
         );
         return UpdateLaunch::Failed;
     }
-    // Nothing waits on the helper - it outlives us deliberately - so both
-    // handles are closed straight away rather than leaked until process exit.
+    // Watch it briefly before believing it (see `SETTLE`), then let it go: the
+    // helper outlives us deliberately, so the handles are closed rather than
+    // held until process exit.
+    // SAFETY: both handles come from a successful CreateProcessW.
+    let exited = unsafe { WaitForSingleObject(process.hProcess, SETTLE.as_millis() as u32) };
+    let mut status: u32 = 0;
+    let status = if exited == WAIT_OBJECT_0 {
+        // SAFETY: the handle is live until CloseHandle below.
+        unsafe { GetExitCodeProcess(process.hProcess, &mut status) };
+        Some(status)
+    } else {
+        None
+    };
     // SAFETY: both handles come from a successful CreateProcessW.
     unsafe {
         CloseHandle(process.hThread);
         CloseHandle(process.hProcess);
+    }
+
+    if let Some(status) = status {
+        tracing::error!(
+            status,
+            "the update helper exited immediately; see mbrc-helper.log"
+        );
+        return UpdateLaunch::Failed;
     }
     tracing::info!(
         pid = process.dwProcessId,

--- a/packages/mbrc-helper/Cargo.toml
+++ b/packages/mbrc-helper/Cargo.toml
@@ -34,6 +34,10 @@ mbrc-buildinfo.workspace = true
 [target.'cfg(windows)'.dependencies]
 windows = { version = "=0.62.2", features = [
     "Win32_System_Threading",
+    # GetCurrentPackageFamilyName: the helper records whether it is running
+    # inside a package container, because a helper that broke out of one logs to
+    # a path that can belong to a different install entirely.
+    "Win32_Storage_Packaging_Appx",
     "Win32_NetworkManagement_WindowsFirewall",
     "Win32_System_Com",
     "Win32_System_Ole",

--- a/packages/mbrc-helper/src/log.rs
+++ b/packages/mbrc-helper/src/log.rs
@@ -48,6 +48,62 @@ pub fn direct_to_storage(staged: &Path) {
     *sink() = choose_sink(staged, &std::env::temp_dir());
 }
 
+/// Records where this process actually is, which is the question every
+/// Store-install failure has turned on.
+///
+/// It is not answerable from the log otherwise, and the ambiguity is not
+/// theoretical: a helper that ran *outside* a package container resolves
+/// `%APPDATA%` literally, and on a machine that also has an ordinary install
+/// that path exists - so its lines append to the *other* install's
+/// `mbrc-helper.log` with nothing to say they came from somewhere else. Two
+/// installs, one file, no attribution. This line is the attribution.
+pub fn note_environment() {
+    let identity = match package_family_name() {
+        Some(family) => format!("packaged ({family})"),
+        None => "unpackaged".to_owned(),
+    };
+    let sink = match sink().as_ref() {
+        Some(path) => path.display().to_string(),
+        None => "nowhere (no usable storage or temp directory)".to_owned(),
+    };
+    line(&format!("running {identity}; logging to {sink}"));
+}
+
+/// This process's package family name, or `None` when it has no package
+/// identity - the ordinary desktop install, and by far the common case.
+#[cfg(windows)]
+fn package_family_name() -> Option<String> {
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS};
+    use windows::Win32::Storage::Packaging::Appx::GetCurrentPackageFamilyName;
+
+    let mut length: u32 = 0;
+    // SAFETY: the documented probe - a null buffer with a zero length asks for
+    // the required size and writes nothing.
+    let probe = unsafe { GetCurrentPackageFamilyName(&mut length, None) };
+    // APPMODEL_ERROR_NO_PACKAGE lands here for an unpackaged process, which is a
+    // normal answer rather than a failure.
+    if probe != ERROR_INSUFFICIENT_BUFFER || length == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u16; length as usize];
+    // SAFETY: `buffer` holds `length` units, which is what the probe asked for.
+    let result =
+        unsafe { GetCurrentPackageFamilyName(&mut length, Some(PWSTR(buffer.as_mut_ptr()))) };
+    if result != ERROR_SUCCESS {
+        return None;
+    }
+    // The reported length counts the terminating null.
+    let end = (length as usize).saturating_sub(1).min(buffer.len());
+    Some(String::from_utf16_lossy(&buffer[..end]))
+}
+
+#[cfg(not(windows))]
+fn package_family_name() -> Option<String> {
+    None
+}
+
 /// Where a line would go, given a staging directory and a fallback directory.
 ///
 /// Split from [`direct_to_storage`] so it can be tested without the fallback

--- a/packages/mbrc-helper/src/main.rs
+++ b/packages/mbrc-helper/src/main.rs
@@ -164,6 +164,7 @@ fn run_update(request: &update::Request<'_>) -> u8 {
     // ("--staged cannot be resolved") is how a packaged install fails, and it
     // used to vanish into a console that does not exist.
     log::direct_to_storage(std::path::Path::new(request.staged));
+    log::note_environment();
     log::line(&format!(
         "update requested: pid={} staged={} target={}",
         request.pid, request.staged, request.target

--- a/packages/mbrc-release/build.rs
+++ b/packages/mbrc-release/build.rs
@@ -50,6 +50,18 @@ fn main() {
         println!("cargo:warning=no release public keys in {} — signature verification will reject every manifest", keys_dir.display());
     }
 
+    // A local testing key is a supported workflow (see tools/stage-local-update.ps1)
+    // and is gitignored, but a build carrying one trusts anything writable in the
+    // staging directory and applies it elevated. Say so on every build: the cost of
+    // shipping such a binary by accident is far higher than the noise.
+    for (name, _) in &keys {
+        if name.starts_with("dev") {
+            println!(
+                "cargo:warning=trusting LOCAL TESTING key {name:?} - this build must never be released"
+            );
+        }
+    }
+
     let mut out = String::from("pub const TRUSTED_KEYS: &[TrustedKey] = &[\n");
     for (name, base64) in &keys {
         out.push_str(&format!(

--- a/tools/stage-local-update.ps1
+++ b/tools/stage-local-update.ps1
@@ -1,0 +1,151 @@
+# Stage a locally built, locally signed update - no GitHub release, no network.
+#
+# WHY THIS EXISTS
+#
+# The only part of the update mechanism that cannot be tested from a working
+# tree is the apply: `elevate::launch` runs the *staged* helper and verifies it
+# against a signed manifest, so a locally built binary is rejected. Testing a
+# change to the launch therefore meant publishing a release and cutting another
+# beta - a slow loop for something that fails in seconds.
+#
+# This stages a bundle by hand instead, reaching the same code path from
+# `pending.json` onwards: verification, the elevation decision, the launch, the
+# backup, the swap, the relaunch and the staging sweep. Everything except check
+# and download, both of which are already known to work.
+#
+# HOW THE SIGNATURE WORKS
+#
+# `mbrc-release/build.rs` compiles every `keys/*.pub` into TRUSTED_KEYS. Drop a
+# locally generated public key in there and a local build trusts it, with no
+# code change. This script generates one on first run if it is missing.
+#
+# `packages/mbrc-release/keys/dev*.pub` is gitignored, so it cannot be committed
+# by accident, and build.rs prints a warning on every build that compiles one in.
+#
+#   SECURITY. A build carrying a dev key trusts bundles anyone able to write to
+#   the staging directory can produce, and the apply is elevated. Never ship a
+#   build made with it. CI builds from a clean checkout, so a stray local key
+#   cannot reach a release - but nothing stops you installing such a build
+#   yourself, so replace it with a real build when you are done testing.
+#
+# USAGE
+#
+#   .\tools\stage-local-update.ps1 -Version 1.5.0-beta.9 -Storage "$env:APPDATA\MusicBee\mb_remote"
+#
+# The version must be NEWER than what is installed, or `is_upgrade` refuses the
+# apply. Build and install a lower-stamped build first.
+
+param(
+    [Parameter(Mandatory = $true)] [string]$Version,
+    [Parameter(Mandatory = $true)] [string]$Storage,
+    [string]$KeyDir = "$env:TEMP\mbrc-devkey",
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$keysDir = Join-Path $root "packages\mbrc-release\keys"
+$pub = Join-Path $KeyDir "dev.pub"
+$sec = Join-Path $KeyDir "dev.key"
+
+function Step($m) { Write-Host "`n==> $m" -ForegroundColor Cyan }
+
+# --- the signing key -------------------------------------------------------
+
+if (-not (Test-Path $sec)) {
+    Step "Generating a local dev keypair in $KeyDir"
+    New-Item -ItemType Directory -Force -Path $KeyDir | Out-Null
+    # -W: passwordless, so signing never blocks on a prompt.
+    rsign generate -W -p $pub -s $sec -c "mbrc local test key" | Out-Null
+}
+
+$trusted = Join-Path $keysDir "dev.pub"
+if (-not (Test-Path $trusted)) {
+    Step "Trusting the dev key for local builds (untracked)"
+    Copy-Item $pub $trusted -Force
+    Write-Host "  copied to packages\mbrc-release\keys\dev.pub (gitignored)" -ForegroundColor Yellow
+    Write-Host "  every build that compiles it in says so; never ship one" -ForegroundColor Yellow
+}
+
+# --- build -----------------------------------------------------------------
+
+if (-not $SkipBuild) {
+    Step "Building stamped $Version"
+    $env:MBRC_VERSION = $Version
+    & (Join-Path $root "build.ps1") -Configuration Release | Out-Null
+}
+
+$out = Join-Path $root "build\bin\plugin\Release\net48"
+$files = @("mb_remote.dll", "mbrc_core.dll", "mbrc-helper.exe")
+foreach ($f in $files) {
+    if (-not (Test-Path (Join-Path $out $f))) { throw "missing build output: $f" }
+}
+
+# --- manifest --------------------------------------------------------------
+
+Step "Writing and signing the manifest"
+
+function Sha512Hex($path) {
+    (Get-FileHash -Algorithm SHA512 -Path $path).Hash.ToLowerInvariant()
+}
+
+$entries = @()
+foreach ($f in $files) {
+    $entries += [ordered]@{ path = $f; sha512 = (Sha512Hex (Join-Path $out $f)) }
+}
+
+# `artifacts` is required by the schema even though a hand-staged bundle is
+# never downloaded; the sizes and hashes below are of the staged files.
+$zipName = "musicbee_remote_$Version.zip"
+$manifest = [ordered]@{
+    schema             = 1
+    channel            = "testing"
+    version            = $Version
+    released_at        = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    abi_version        = 1
+    min_musicbee_build = 6500
+    notes_url          = "https://example.invalid/local-test"
+    artifacts          = [ordered]@{
+        zip       = [ordered]@{ name = $zipName; size = 1; sha512 = $entries[0].sha512 }
+        installer = [ordered]@{ name = "musicbee_remote_$Version.exe"; size = 1; sha512 = $entries[0].sha512 }
+    }
+    files              = $entries
+}
+
+$staged = Join-Path $Storage "updates\$Version"
+New-Item -ItemType Directory -Force -Path $staged | Out-Null
+
+$manifestPath = Join-Path $staged "manifest.json"
+# No BOM: the bytes are what gets signed and verified.
+[IO.File]::WriteAllText($manifestPath, ($manifest | ConvertTo-Json -Depth 6), [Text.UTF8Encoding]::new($false))
+
+rsign sign -W -s $sec -x (Join-Path $staged "manifest.json.minisig") `
+    -t "MusicBee Remote $Version (local test)" $manifestPath | Out-Null
+
+# --- stage -----------------------------------------------------------------
+
+Step "Staging into $staged"
+foreach ($f in $files) {
+    Copy-Item (Join-Path $out $f) (Join-Path $staged $f) -Force
+    Write-Host ("  {0}" -f $f)
+}
+
+# The marker is what tells the core something is pending.
+# `files` is REQUIRED by mbrc_release::stage::Pending. Without it the marker
+# fails to deserialize, the core logs "the staged-update marker is unreadable"
+# and silently ignores the whole bundle - the panel then just offers a check.
+$pending = [ordered]@{
+    schema    = 1
+    version   = $Version
+    staged_at = $manifest.released_at
+    files     = @($files)
+}
+[IO.File]::WriteAllText(
+    (Join-Path $Storage "updates\pending.json"),
+    ($pending | ConvertTo-Json -Depth 4),
+    [Text.UTF8Encoding]::new($false))
+
+Write-Host ""
+Write-Host "Staged $Version." -ForegroundColor Green
+Write-Host "Restart MusicBee; the Updates panel should offer 'restart to install'."
+Write-Host "The INSTALLED build must be older than $Version and must also trust the dev key."

--- a/tools/stage-local-update.ps1
+++ b/tools/stage-local-update.ps1
@@ -57,22 +57,39 @@ if (-not (Test-Path $sec)) {
     New-Item -ItemType Directory -Force -Path $KeyDir | Out-Null
     # -W: passwordless, so signing never blocks on a prompt.
     rsign generate -W -p $pub -s $sec -c "mbrc local test key" | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "rsign generate failed ($LASTEXITCODE)" }
 }
 
+# Copied UNCONDITIONALLY, not just when it is missing. $KeyDir defaults under
+# $env:TEMP, which Storage Sense wipes, while keys\dev.pub survives - so
+# "generate a new keypair, keep trusting the old public half" is a state this
+# reaches on its own. It signs with a key the build does not trust and the apply
+# refuses with a bare VerifyFailed that names nothing.
 $trusted = Join-Path $keysDir "dev.pub"
-if (-not (Test-Path $trusted)) {
-    Step "Trusting the dev key for local builds (untracked)"
-    Copy-Item $pub $trusted -Force
-    Write-Host "  copied to packages\mbrc-release\keys\dev.pub (gitignored)" -ForegroundColor Yellow
-    Write-Host "  every build that compiles it in says so; never ship one" -ForegroundColor Yellow
-}
+Step "Trusting the dev key for local builds"
+Copy-Item $pub $trusted -Force
+Write-Host "  packages\mbrc-release\keys\dev.pub (gitignored)" -ForegroundColor Yellow
+Write-Host "  every build that compiles it in says so; never ship one" -ForegroundColor Yellow
 
 # --- build -----------------------------------------------------------------
 
 if (-not $SkipBuild) {
     Step "Building stamped $Version"
-    $env:MBRC_VERSION = $Version
-    & (Join-Path $root "build.ps1") -Configuration Release | Out-Null
+    # $env: assignments are process-wide, not script-scoped: without restoring
+    # it, every later build in this shell is stamped with the test version, and
+    # such a build refuses real updates because is_upgrade compares against it.
+    $previousVersion = $env:MBRC_VERSION
+    try {
+        $env:MBRC_VERSION = $Version
+        & (Join-Path $root "build.ps1") -Configuration Release | Out-Null
+        # Out-Null hides the failure and stale artifacts satisfy the Test-Path
+        # check below, so without this a broken build stages the PREVIOUS
+        # binaries under the new version and the test run proves nothing.
+        if ($LASTEXITCODE -ne 0) { throw "build.ps1 failed ($LASTEXITCODE)" }
+    }
+    finally {
+        $env:MBRC_VERSION = $previousVersion
+    }
 }
 
 $out = Join-Path $root "build\bin\plugin\Release\net48"
@@ -121,6 +138,7 @@ $manifestPath = Join-Path $staged "manifest.json"
 
 rsign sign -W -s $sec -x (Join-Path $staged "manifest.json.minisig") `
     -t "MusicBee Remote $Version (local test)" $manifestPath | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "rsign sign failed ($LASTEXITCODE)" }
 
 # --- stage -----------------------------------------------------------------
 


### PR DESCRIPTION
Auto-update did not work on the Microsoft Store build: it staged the bundle, closed MusicBee, silently did nothing, and never reopened. #179 made that failure visible and guessed at a fix. The guess was wrong. This is the fix, verified end to end on a real Store install.

## The cause

A `CreateProcess` child of a packaged (MSIX) app does **not** inherit the package container, and that is documented default behaviour rather than an anomaly: `PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY` defaults to `PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_ENABLE_PROCESS_TREE`, which puts children *outside* the desktop app runtime environment. The helper then sees the un-redirected `%APPDATA%`, where nothing we staged exists, and correctly refuses:

```
--staged "C:\Users\...\AppData\Roaming\MusicBee\mb_remote\updates\1.5.0-beta.4"
cannot be resolved: The system cannot find the path specified. (os error 3)
```

The job object a packaged app runs in was the other suspect and is **ruled out** — observed twice, the helper ran, logged, and exited on its own both times.

## The fix

A packaged parent now launches the helper through raw `CreateProcessW` with an attribute list setting `PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE`, so the child sees exactly what the core sees and the existing argv needs no translation. `std::process::Command` cannot set proc-thread attributes, hence the raw call.

That is why this beats the fallback of resolving container paths with `GetFinalPathNameByHandleW` before passing them: that yields `\?\`-prefixed paths, and the helper's `checked_path` rejects a leading double backslash as a UNC path.

Unpackaged installs keep the plain `Command::spawn`. The elevated `ShellExecuteExW` branch is untouched — `CreateProcess` cannot elevate, and a packaged install never takes it anyway, since its plugins folder is user-writable.

## Two diagnostics this investigation paid for

**The helper records its package identity and log destination.** A helper outside the container resolves `%APPDATA%` literally, and on a machine that also has an ordinary install that path *exists* — so its lines appended to the **other** install's `mbrc-helper.log` with nothing to say they came from elsewhere. Two installs, one file, no attribution. It read as total silence.

**A helper that exits immediately is no longer reported as `Launched`.** `Launched` makes the panel close MusicBee, so a helper that has already refused gives the worst outcome available: MusicBee shuts, nothing is applied, no window is left to say so. Every refusal reachable before the helper starts waiting happens in milliseconds, while a healthy one then waits two minutes for MusicBee, so a 750ms watch separates them cleanly.

## Local update testing, without cutting a release

`mbrc-release/build.rs` compiles every `keys/*.pub` into `TRUSTED_KEYS`, so a locally generated key makes a local build trust a locally signed bundle. `keys/dev*.pub` is now gitignored and `build.rs` warns on every build that compiles one in, because such a build trusts any bundle writable in the staging directory and applies it elevated.

`tools/stage-local-update.ps1` is committed for the same reason — it is now the supported way to exercise an apply. It had two bugs that cost real time while untracked: a PowerShell parse error on a reserved `<`, and a `pending.json` missing the required `files` field, which makes the core silently ignore a perfectly good staged bundle and answer "no updates".

## Verified live

Two full runs on the Store install (`50072StevenMayall.MusicBee_kcr266et74avj`), beta.3 → beta.4 and beta.4 → beta.5, no release cut:

```
started the update helper inside the package container pid=22332
running packaged (50072StevenMayall.MusicBee_kcr266et74avj); logging to ...\mb_remote\mbrc-helper.log
manifest for 1.5.0-beta.5 signed by dev
backed up 3 file(s) -> wrote mb_remote.dll, mbrc_core.dll, mbrc-helper.exe
applied 1.5.0-beta.5 (3 file(s))
relaunched shell:AppsFolder\50072StevenMayall.MusicBee_kcr266et74avj!MusicBeePackage
removed an applied update's staging directory
```

That also closes two items that had never been exercised:

- **the AUMID relaunch**, previously untestable because no run reached it
- **the staging sweep (#177) on a packaged install**, on real residue the helper genuinely could not delete (it runs from inside that directory)

Not verified: nothing on the unpackaged paths changed behaviour beyond the 750ms settle, and the elevated branch is untouched. Refs #24.
