### PR TITLE
chore(core): remove files earlier versions left behind

### DIFF
--- a/packages/mbrc-core/src/legacy.rs
+++ b/packages/mbrc-core/src/legacy.rs
@@ -24,9 +24,26 @@
 //!   create it aim a delete somewhere else. So is a file with more than one hard
 //!   link, which `is_file()` alone cannot tell apart from an ordinary one - the
 //!   name would be ours to remove, but the data would not.
+//! - **Absolute directories only.** A relative one would resolve against the
+//!   process working directory, which for us is MusicBee's install folder - so
+//!   an empty or relative storage path would aim these deletes at a directory
+//!   nobody chose. The helper's `checked_path` refuses relative paths for the
+//!   same reason.
+//! - **No descending through a link.** The leaf check above does not cover the
+//!   directory components above it, and `cache/` is the one component this
+//!   walks through. A junction there would redirect the delete wholesale, so it
+//!   has to be a real directory - the same rule the update staging code applies
+//!   to its own directories.
 //! - **Best effort, never fatal.** A file that cannot be removed is logged and
 //!   skipped. This runs during startup and must never be the reason the plugin
 //!   does not start.
+//!
+//! What is deliberately *not* defended against is the window between the check
+//! and the delete. It does not need to be: both platforms unlink the name rather
+//! than following it, so a link swapped in after the check is itself what gets
+//! removed, never its target. And everything here runs unelevated, as the user
+//! who already owns these directories - so there is no privilege to gain by
+//! racing it.
 
 use std::path::Path;
 
@@ -71,6 +88,16 @@ const RETIRED_PLUGIN_FILES: &[&str] = &["firewall-utility.exe"];
 /// decision to make based on it.
 pub fn sweep(storage_path: &str, plugins_dir: Option<&Path>) {
     let storage = Path::new(storage_path);
+    if !storage.is_absolute() {
+        // Relative would resolve against MusicBee's install directory. Nothing
+        // should ever hand us one, which is exactly why it is worth saying so
+        // instead of quietly deleting somewhere else.
+        tracing::warn!(
+            path = %storage.display(),
+            "not sweeping: the storage path is not absolute"
+        );
+        return;
+    }
 
     let mut removed = 0usize;
     let mut freed = 0u64;
@@ -98,9 +125,16 @@ pub fn sweep(storage_path: &str, plugins_dir: Option<&Path>) {
 
     // Renamed rather than deleted when the cover state moved into redb, as a
     // safety net for a migration that has long since shipped.
-    if let Some(size) = remove_file(&storage.join("cache"), "state.json.migrated") {
-        removed += 1;
-        freed += size;
+    //
+    // This is the only directory component the sweep walks through, and the
+    // leaf's reparse-point check says nothing about it: a junction here would
+    // redirect the delete somewhere else entirely.
+    let cache = storage.join("cache");
+    if is_real_directory(&cache) {
+        if let Some(size) = remove_file(&cache, "state.json.migrated") {
+            removed += 1;
+            freed += size;
+        }
     }
 
     // The plugins directory is not writable on a standard installation, and does
@@ -169,6 +203,26 @@ fn remove_file(dir: &Path, name: &str) -> Option<u64> {
             tracing::debug!(path = %path.display(), error = %e, "could not remove a file from an earlier version");
             None
         }
+    }
+}
+
+/// Whether `path` is a directory in its own right, rather than a link to one.
+///
+/// Absent is not an error - there is simply nothing to sweep - and neither is a
+/// junction: it just means the sweep stops rather than following it.
+fn is_real_directory(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() => true,
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "not sweeping through a link that stands where a directory should"
+                );
+            }
+            false
+        }
+        Err(_) => false,
     }
 }
 
@@ -331,6 +385,53 @@ mod tests {
         );
         assert!(dir.join("somebody-elses-file").exists());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_relative_storage_path_sweeps_nothing() {
+        // Would otherwise resolve against MusicBee's install directory.
+        let dir = scratch("relative");
+        write(&dir, "mbrc.log", "must survive");
+        let previous = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&dir).expect("chdir");
+
+        sweep(".", None);
+
+        std::env::set_current_dir(previous).expect("restore cwd");
+        assert!(
+            dir.join("mbrc.log").exists(),
+            "a relative path must be refused, not resolved"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_sweep_does_not_follow_a_link_standing_in_for_the_cache_directory() {
+        let dir = scratch("cache-link");
+        // Somewhere else entirely, holding a file with the name we delete.
+        let elsewhere = scratch("cache-link-target");
+        write(&elsewhere, "state.json.migrated", "not ours to delete");
+
+        std::fs::remove_dir_all(dir.join("cache")).expect("clear the real cache dir");
+        #[cfg(windows)]
+        let linked = std::os::windows::fs::symlink_dir(&elsewhere, dir.join("cache")).is_ok();
+        #[cfg(not(windows))]
+        let linked = std::os::unix::fs::symlink(&elsewhere, dir.join("cache")).is_ok();
+        if !linked {
+            // Creating one needs a privilege we may not have; nothing to prove.
+            let _ = std::fs::remove_dir_all(&dir);
+            let _ = std::fs::remove_dir_all(&elsewhere);
+            return;
+        }
+
+        sweep(dir.to_str().unwrap(), None);
+
+        assert!(
+            elsewhere.join("state.json.migrated").exists(),
+            "a junction in place of cache/ must stop the sweep, not redirect it"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&elsewhere);
     }
 
     #[test]

--- a/packages/mbrc-core/src/legacy.rs
+++ b/packages/mbrc-core/src/legacy.rs
@@ -116,7 +116,14 @@ pub fn sweep(storage_path: &str, plugins_dir: Option<&Path>) {
     // runs whenever `core_settings.json` is absent, so leaving the XML in place
     // means deleting the JSON to reset the settings silently restores the old
     // ones instead. Reset should mean reset.
-    if storage.join("core_settings.json").is_file() {
+    //
+    // Non-empty, not merely present: `migrate_legacy_settings` writes the JSON
+    // with create-truncate-write, so a second MusicBee starting at that exact
+    // moment would otherwise see a zero-length file, call the migration done and
+    // delete the only copy of the settings. Two instances sharing one %APPDATA%
+    // is ordinary - a Program Files and a portable install do - and this is the
+    // one file here whose loss costs the user something.
+    if migrated_settings_are_present(storage) {
         if let Some(size) = remove_file(storage, "settings.xml") {
             removed += 1;
             freed += size;
@@ -204,6 +211,13 @@ fn remove_file(dir: &Path, name: &str) -> Option<u64> {
             None
         }
     }
+}
+
+/// Whether `core_settings.json` is there *and* has something in it.
+fn migrated_settings_are_present(storage: &Path) -> bool {
+    std::fs::metadata(storage.join("core_settings.json"))
+        .map(|meta| meta.is_file() && meta.len() > 0)
+        .unwrap_or(false)
 }
 
 /// Whether `path` is a directory in its own right, rather than a link to one.
@@ -329,6 +343,23 @@ mod tests {
             !dir.join("settings.xml").exists(),
             "migrated, so the XML must go - otherwise deleting core_settings.json \
              to reset the settings silently restores the old ones instead"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn an_empty_settings_file_does_not_count_as_migrated() {
+        // What a second MusicBee sees if it starts while the first is between
+        // the create and the write of core_settings.json.
+        let dir = scratch("half-written");
+        write(&dir, "settings.xml", "<settings/>");
+        write(&dir, "core_settings.json", "");
+
+        sweep(dir.to_str().unwrap(), None);
+
+        assert!(
+            dir.join("settings.xml").exists(),
+            "a zero-length settings file must not be taken as a completed migration"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/packages/mbrc-core/src/legacy.rs
+++ b/packages/mbrc-core/src/legacy.rs
@@ -1,0 +1,351 @@
+//! Removing files earlier versions left behind.
+//!
+//! Nothing removes them otherwise. The updater's manifest is an allowlist of
+//! what a release *writes*; it has no notion of what a release *retires*, and
+//! only the NSIS installer deletes anything - which covers exactly one of the
+//! three ways the plugin gets installed. A zip extraction and the Store's "Add
+//! Plugin" both only ever add files, so a machine that started on 1.4.x keeps
+//! its 1.4.x leftovers forever.
+//!
+//! Deleting files is the kind of convenience that turns into a bug report, so
+//! the rules here are deliberately narrow:
+//!
+//! - **Exact names, compiled in.** No globs and no "delete what looks old". The
+//!   only pattern is a bounded numeric one for a rotation scheme we shipped
+//!   ourselves, and it is spelled out rather than matched loosely.
+//! - **Only two directories, and only bare names inside them.** The plugins
+//!   directory is derived - asked of the loader, so it is true by construction.
+//!   The storage directory is *not*: it arrives over FFI from the C# side, which
+//!   takes it from MusicBee. That is not a path an attacker picks, but it is
+//!   supplied rather than derived, so the names joined onto it carry the weight
+//!   here - every one is a compile-time constant with no separator in it.
+//! - **Regular files, singly linked.** A directory or a reparse point with a
+//!   matching name is left alone: following one would let anything able to
+//!   create it aim a delete somewhere else. So is a file with more than one hard
+//!   link, which `is_file()` alone cannot tell apart from an ordinary one - the
+//!   name would be ours to remove, but the data would not.
+//! - **Best effort, never fatal.** A file that cannot be removed is logged and
+//!   skipped. This runs during startup and must never be the reason the plugin
+//!   does not start.
+
+use std::path::Path;
+
+/// Logs from the pre-1.5.0 C# plugin, which used NLog with its own rotation.
+///
+/// The 1.5.0 core writes `mbrc-core.log` and rotates it itself, so nothing has
+/// written these since the rewrite. They are the bulk of what is left behind -
+/// six files, and megabytes rather than bytes.
+const LEGACY_LOGS: &[&str] = &[
+    "mbrc.log",
+    "mbrc.0.log",
+    "mbrc.1.log",
+    "mbrc.2.log",
+    "mbrc.3.log",
+    "mbrc.4.log",
+    // 1.4.x named its log this before the NLog rotation existed.
+    "error.log",
+];
+
+/// The C# firewall utility, replaced by `mbrc-helper.exe` in 1.5.0.
+///
+/// The NSIS installer already deletes this on both install and uninstall; this
+/// is for the routes it does not run on.
+///
+/// `License.txt` is deliberately absent, though a 1.4.x-era copy does turn up
+/// beside our own `LICENSE` in the wild. It is probably ours, but the plugins
+/// folder is shared with every other MusicBee plugin and a generically named
+/// file there cannot be proven to be. Deleting someone else's file to reclaim
+/// 38 KB is not a trade worth making, and "probably" is not the standard this
+/// list is held to.
+const RETIRED_PLUGIN_FILES: &[&str] = &["firewall-utility.exe"];
+
+/// Sweeps the storage directory, and the plugins directory when one was
+/// resolved.
+///
+/// Nothing checks whether either is writable first: on a standard installation
+/// the plugins directory is not, and the delete simply fails and is skipped -
+/// which is correct there anyway, because the installer removes that file on its
+/// own route.
+///
+/// Returns nothing: every outcome here is advisory, and the caller has no
+/// decision to make based on it.
+pub fn sweep(storage_path: &str, plugins_dir: Option<&Path>) {
+    let storage = Path::new(storage_path);
+
+    let mut removed = 0usize;
+    let mut freed = 0u64;
+    for name in LEGACY_LOGS {
+        if let Some(size) = remove_file(storage, name) {
+            removed += 1;
+            freed += size;
+        }
+    }
+
+    // `settings.xml` is only inert once the core has its own settings file.
+    // Until then it is the one record of a 1.4.x user's configuration and
+    // `migrate_legacy_settings` still needs it.
+    //
+    // Removing it afterwards is not tidiness for its own sake: the migration
+    // runs whenever `core_settings.json` is absent, so leaving the XML in place
+    // means deleting the JSON to reset the settings silently restores the old
+    // ones instead. Reset should mean reset.
+    if storage.join("core_settings.json").is_file() {
+        if let Some(size) = remove_file(storage, "settings.xml") {
+            removed += 1;
+            freed += size;
+        }
+    }
+
+    // Renamed rather than deleted when the cover state moved into redb, as a
+    // safety net for a migration that has long since shipped.
+    if let Some(size) = remove_file(&storage.join("cache"), "state.json.migrated") {
+        removed += 1;
+        freed += size;
+    }
+
+    // The plugins directory is not writable on a standard installation, and does
+    // not need to be: the installer deletes this one itself. Portable and Store
+    // installations are writable and have no installer, which is the gap.
+    if let Some(plugins) = plugins_dir {
+        for name in RETIRED_PLUGIN_FILES {
+            if let Some(size) = remove_file(plugins, name) {
+                removed += 1;
+                freed += size;
+            }
+        }
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            files = removed,
+            freed_bytes = freed,
+            "removed files left behind by an earlier version"
+        );
+    }
+}
+
+/// Removes one bare filename from `dir`, returning the bytes reclaimed.
+///
+/// `None` covers every uninteresting case - not there, not a regular file, or
+/// not removable - because none of them changes what the caller does.
+fn remove_file(dir: &Path, name: &str) -> Option<u64> {
+    debug_assert!(
+        !name.contains(['/', '\\', ':']) && name != ".." && name != ".",
+        "legacy sweep names must be bare filenames"
+    );
+    let path = dir.join(name);
+
+    // `symlink_metadata` does not follow: a reparse point named like one of our
+    // files is left exactly where it is.
+    let meta = std::fs::symlink_metadata(&path).ok()?;
+    if !meta.is_file() {
+        if meta.file_type().is_symlink() {
+            tracing::warn!(path = %path.display(), "leaving a link that shares a retired file's name");
+        }
+        return None;
+    }
+
+    if is_multiply_linked(&path, &meta) {
+        // Deliberately vague: this is also how "could not be opened to check"
+        // arrives, and naming a cause we have not established would send whoever
+        // reads it the wrong way.
+        tracing::warn!(
+            path = %path.display(),
+            "leaving a retired name that could not be shown to be safe to unlink"
+        );
+        return None;
+    }
+
+    let size = meta.len();
+    match std::fs::remove_file(&path) {
+        Ok(()) => {
+            tracing::debug!(path = %path.display(), size, "removed a file from an earlier version");
+            Some(size)
+        }
+        Err(e) => {
+            // Read-only media, a locked file, a directory we cannot write. All
+            // of them mean "leave it", and none of them is worth a warning on
+            // every start.
+            tracing::debug!(path = %path.display(), error = %e, "could not remove a file from an earlier version");
+            None
+        }
+    }
+}
+
+/// Whether more than one directory entry points at this file's data.
+///
+/// `is_file()` cannot see the difference, and the difference matters: unlinking
+/// a name we recognise is fine, but only when that name is the only way to the
+/// data. Anything unexpected here counts as multiply linked - refusing to delete
+/// on a doubt costs a few kilobytes, and the alternative costs someone's file.
+#[cfg(windows)]
+fn is_multiply_linked(path: &Path, _meta: &std::fs::Metadata) -> bool {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    // The link count is not on the stable `Metadata` for Windows, so it takes a
+    // handle. Opening for read is enough, and a file we cannot even open is one
+    // we are certainly not going to delete.
+    let Ok(file) = std::fs::File::open(path) else {
+        return true;
+    };
+    let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+    // SAFETY: the handle is live for the call, and `info` is a plain
+    // out-parameter of the size the API expects.
+    let ok = unsafe { GetFileInformationByHandle(file.as_raw_handle() as HANDLE, &mut info) };
+    if ok == 0 {
+        return true;
+    }
+    info.nNumberOfLinks > 1
+}
+
+#[cfg(not(windows))]
+fn is_multiply_linked(_path: &Path, meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    meta.nlink() > 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(case: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("mbrc-legacy-{case}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("cache")).expect("scratch");
+        dir
+    }
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(name), body).expect("write");
+    }
+
+    #[test]
+    fn removes_the_old_logs_and_leaves_the_current_ones() {
+        let dir = scratch("logs");
+        for name in ["mbrc.log", "mbrc.0.log", "mbrc.4.log", "error.log"] {
+            write(&dir, name, "old");
+        }
+        // Everything the 1.5 core owns must survive untouched.
+        for name in [
+            "mbrc-core.log",
+            "mbrc-core.1.log.gz",
+            "mbrc-bootstrap.log",
+            "mbrc-helper.log",
+            "mbrc.redb",
+            "update_state.json",
+        ] {
+            write(&dir, name, "current");
+        }
+
+        sweep(dir.to_str().unwrap(), None);
+
+        for name in ["mbrc.log", "mbrc.0.log", "mbrc.4.log", "error.log"] {
+            assert!(!dir.join(name).exists(), "{name} should have been removed");
+        }
+        for name in [
+            "mbrc-core.log",
+            "mbrc-core.1.log.gz",
+            "mbrc-bootstrap.log",
+            "mbrc-helper.log",
+            "mbrc.redb",
+            "update_state.json",
+        ] {
+            assert!(dir.join(name).exists(), "{name} must be left alone");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn keeps_legacy_settings_until_they_have_been_migrated() {
+        let dir = scratch("unmigrated");
+        write(&dir, "settings.xml", "<settings/>");
+
+        // No core_settings.json yet: the migration still needs the XML, and
+        // removing it here would lose a 1.4.x user's configuration outright.
+        sweep(dir.to_str().unwrap(), None);
+        assert!(dir.join("settings.xml").exists(), "not yet migrated");
+
+        write(&dir, "core_settings.json", "{}");
+        sweep(dir.to_str().unwrap(), None);
+        assert!(
+            !dir.join("settings.xml").exists(),
+            "migrated, so the XML must go - otherwise deleting core_settings.json \
+             to reset the settings silently restores the old ones instead"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn removes_the_retired_utility_from_the_plugins_directory() {
+        let dir = scratch("plugins");
+        let plugins = dir.join("Plugins");
+        std::fs::create_dir_all(&plugins).expect("plugins");
+        write(&plugins, "firewall-utility.exe", "retired");
+        write(&plugins, "mb_remote.dll", "current");
+        write(&plugins, "mbrc_core.dll", "current");
+        write(&plugins, "mbrc-helper.exe", "current");
+
+        sweep(dir.to_str().unwrap(), Some(&plugins));
+
+        assert!(!plugins.join("firewall-utility.exe").exists());
+        for name in ["mb_remote.dll", "mbrc_core.dll", "mbrc-helper.exe"] {
+            assert!(plugins.join(name).exists(), "{name} must be left alone");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_directory_sharing_a_retired_name_is_not_touched() {
+        // Nothing should ever create one, which is exactly why a delete that
+        // would recurse into it must not be reachable.
+        let dir = scratch("directory");
+        std::fs::create_dir_all(dir.join("mbrc.log")).expect("directory");
+        std::fs::write(dir.join("mbrc.log").join("inside"), "keep").expect("write");
+
+        sweep(dir.to_str().unwrap(), None);
+
+        assert!(dir.join("mbrc.log").join("inside").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_hard_linked_file_is_left_alone() {
+        // The name would be ours to remove; the data behind it would not be.
+        let dir = scratch("hardlink");
+        write(&dir, "somebody-elses-file", "important");
+        if std::fs::hard_link(dir.join("somebody-elses-file"), dir.join("mbrc.log")).is_err() {
+            // Filesystems that cannot do this have nothing to test.
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+
+        sweep(dir.to_str().unwrap(), None);
+
+        assert!(
+            dir.join("mbrc.log").exists(),
+            "a hard link must not be unlinked"
+        );
+        assert!(dir.join("somebody-elses-file").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sweeping_an_already_clean_directory_does_nothing() {
+        let dir = scratch("clean");
+        write(&dir, "mbrc-core.log", "current");
+        sweep(dir.to_str().unwrap(), None);
+        assert!(dir.join("mbrc-core.log").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_storage_directory_is_not_an_error() {
+        let dir = std::env::temp_dir().join("mbrc-legacy-absent");
+        let _ = std::fs::remove_dir_all(&dir);
+        sweep(dir.to_str().unwrap(), None);
+    }
+}

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cover;
 pub mod diagnostics;
 pub mod discovery;
 pub mod ffi;
+pub mod legacy;
 pub mod logging;
 pub mod mdns;
 pub mod metadata_cache;
@@ -94,6 +95,9 @@ pub unsafe extern "C" fn mbrc_initialize(
         // it to core_settings.json before loading (one-time, best-effort).
         config::migrate_legacy_settings(&storage_path);
         let config = config::Config::load(&storage_path);
+        // After the migration and the load, so `settings.xml` is only removed
+        // once its contents are safely in `core_settings.json`.
+        legacy::sweep(&storage_path, updates::elevate::plugins_dir().as_deref());
         let providers: Arc<dyn Providers> =
             Arc::new(FfiProviders::new(SafeCallbacks::new(callbacks)));
         let result = state::initialize(providers, config);

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -288,7 +288,7 @@ fn is_writable(dir: &Path) -> bool {
 /// directory. Asked of the loader rather than assembled from a MusicBee path:
 /// this is the one answer that is true by construction.
 #[cfg(windows)]
-fn plugins_dir() -> Option<PathBuf> {
+pub(crate) fn plugins_dir() -> Option<PathBuf> {
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::HMODULE;
     use windows_sys::Win32::System::LibraryLoader::{
@@ -323,7 +323,7 @@ fn plugins_dir() -> Option<PathBuf> {
 }
 
 #[cfg(not(windows))]
-fn plugins_dir() -> Option<PathBuf> {
+pub(crate) fn plugins_dir() -> Option<PathBuf> {
     std::env::current_exe()
         .ok()
         .and_then(|exe| exe.parent().map(Path::to_path_buf))


### PR DESCRIPTION
Nothing removes what an earlier version left behind. The updater's manifest is an allowlist of what a release *writes* and has no notion of what a release *retires*, and only the NSIS installer deletes anything — which covers one of the three ways the plugin gets installed. A zip extraction and the Store's "Add Plugin" both only ever add files, so a machine that started on 1.4.x keeps its 1.4.x leftovers forever.

On the Microsoft Store install used for testing that was **9 files and 10.1 MB**.

## What gets swept

From the storage directory, and the plugins directory when one was resolved:

| File | Why it is dead |
| --- | --- |
| `mbrc.log`, `mbrc.0.log` … `mbrc.4.log` | pre-1.5.0 NLog output; the Rust core owns `mbrc-core.log` and rotates it itself |
| `error.log` | what 1.4.x called its log before the rotation existed |
| `cache/state.json.migrated` | renamed rather than deleted when the cover state moved into redb |
| `firewall-utility.exe` | replaced by `mbrc-helper.exe` in 1.5.0 (the installer already deletes it on its own route) |
| `settings.xml` | **only once `core_settings.json` exists** — see below |

## The settings condition is a bug fix, not tidiness

`migrate_legacy_settings` runs whenever `core_settings.json` is **absent**. Leaving the XML in place therefore means deleting the JSON to reset the settings silently restores the *old* ones instead of falling back to defaults. Reset should mean reset.

Until the migration has run, the XML is the only record of a 1.4.x user's configuration, so it must stay — hence the condition rather than an unconditional delete.

## Safety

Deleting files is the kind of convenience that turns into a bug report, so the rules are narrow, and they are the same ones `mbrc-helper`'s `checked_path` already applies:

- **Exact compiled-in names.** No globs, no "delete what looks old". The only pattern is a rotation scheme we shipped ourselves, spelled out rather than matched.
- **Absolute directories only.** A relative one resolves against the process working directory — MusicBee's install folder — so an empty or relative storage path would aim the deletes at a directory nobody chose.
- **Regular files, singly linked.** `symlink_metadata` leaves a reparse point sharing a retired name alone; a hard-link check leaves a file whose data another name also points at, since `is_file()` cannot tell those apart and the name would be ours to unlink while the data would not. Anything that cannot be checked counts as unsafe.
- **No descending through a link.** `cache/` is the one directory component the sweep walks through, and the leaf check says nothing about it, so it has to be a real directory.
- **Best effort, never fatal.** This runs during startup and must never be why the plugin fails to start.

Deliberately not defended, and the module says so: the window between the check and the delete. Both platforms unlink the name rather than following it, so a link swapped in afterwards is itself what gets removed and never its target — and the sweep runs unelevated, as the user who already owns these directories, so there is no privilege to gain by racing it.

Only one of the two directories is genuinely derived, which the module states rather than glosses: the plugins directory is asked of the loader, while the storage directory arrives over FFI from the host. The names joined onto it carry the weight there, and every one is a compile-time constant.

## Verified live

Run on the real Store install, which had the full set of leftovers:

```
removed files left behind by an earlier version  files=9  freed_bytes=10563599
```

Storage went from 40 MB to 30 MB. Everything that should have survived did — `core_settings.json` byte-identical, all 1420 cover files, `mbrc.redb`, and the three current plugin files. `LICENSE`, `License.txt` and `README.txt` were left in the plugins folder. The plugin came up healthy afterwards: server listening, discovery up, library reconciled with `rebuilt=false`, so nothing forced a cache rebuild.

**A decoy also settled a question the MSIX container raised.** Reads demonstrably fall through from a packaged app to the real `%APPDATA%` — that is how a Store install consumed a bundle staged for a Program Files one earlier the same day. A decoy `mbrc.0.log` planted in the unpackaged storage survived a full Store start with an identical checksum, so **deletes do not cross the container boundary** and a Store user cannot damage a desktop install's files.

## Tests

14 in the module: the removals, the current files that must survive, the settings condition in both directions, a directory sharing a retired name, a hard link, a relative path, and a link standing in for `cache/`. 212 in the core overall.

The junction test needs a privilege Windows does not grant by default, so it returns early there and runs for real on the Linux CI leg. The live run above predates the hard-link and path guards, which only ever prevent deletions.

`License.txt` is deliberately not swept. A 1.4.x-era copy turns up beside our own `LICENSE`, and it is probably ours — but the plugins folder is shared with every other MusicBee plugin and a generically named file there cannot be proven to be. The rationale is recorded next to the list so it is not re-litigated.


## Ordering and concurrency

The sweep runs at the first startup *after* an upgrade, which is where it belongs: the newly installed core is the one that knows what its own version retired. The helper does `apply` → `clear_staged` → `relaunch`, so it has finished before MusicBee restarts and the core that sweeps does not exist until after; their filenames are disjoint in any case.

Two sweeps racing over the same directory is benign — the loser gets `NotFound`, skips, and logs at debug. That is not hypothetical: a Program Files and a portable MusicBee share one `%APPDATA%`.

One window was real and is fixed in `72b879f`. `migrate_legacy_settings` writes `core_settings.json` with create-truncate-write, so a second MusicBee starting inside that window would see a zero-length file, conclude the migration was done, and delete the only remaining copy of the user's 1.4.x settings. The file now has to be present **and** non-empty. `settings.xml` is the one file this sweep touches whose loss actually costs the user something, so it is worth the extra `stat`.
