### PR TITLE
fix: null-safe now-playing queries and a quiet staging sweep

### DIFF
--- a/packages/mbrc-helper/src/update.rs
+++ b/packages/mbrc-helper/src/update.rs
@@ -413,7 +413,15 @@ fn prune_backups(plan: &Plan, keep: &str) {
 pub fn clear_staged(plan: &Plan) {
     // `<storage>/updates/<version>` -> remove the version directory and the
     // marker beside it, which is what tells the core something is pending.
-    if let Err(e) = std::fs::remove_dir_all(&plan.staged) {
+    if running_from(&plan.staged) {
+        // Windows will not unlink a running image, so this delete cannot succeed
+        // from here and used to log an access-denied error on every successful
+        // apply - a failure line in a log people only open when something broke.
+        // The core sweeps the directory on the next start instead.
+        crate::log::line(
+            "left the staged bundle for the core to sweep: the helper is running from it",
+        );
+    } else if let Err(e) = std::fs::remove_dir_all(&plan.staged) {
         crate::log::line(&format!("could not remove {}: {e}", plan.staged.display()));
     }
     if let Some(updates) = plan.staged.parent() {
@@ -423,6 +431,28 @@ pub fn clear_staged(plan: &Plan) {
                 crate::log::line(&format!("could not remove {}: {e}", marker.display()));
             }
         }
+    }
+}
+
+/// Whether this process's own image lives inside `dir`.
+///
+/// True for every ordinary apply: the core launches
+/// `<storage>/updates/<version>/mbrc-helper.exe` deliberately, because the
+/// installed helper is one of the files being replaced. Falls back to false when
+/// the executable path cannot be resolved - then the delete is attempted and any
+/// failure is reported, which is the honest answer when we cannot tell.
+fn running_from(dir: &Path) -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(parent) = exe.parent() else {
+        return false;
+    };
+    // Compared canonicalized: `dir` arrives verbatim-prefixed (`\\?\...`) and
+    // `current_exe` does not, so the raw paths never match.
+    match (std::fs::canonicalize(parent), std::fs::canonicalize(dir)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => parent == dir,
     }
 }
 
@@ -1046,6 +1076,20 @@ mod tests {
             plan.relaunch,
             RelaunchTarget::Packaged("Family_abc!App".into())
         );
+    }
+
+    #[test]
+    fn the_staged_bundle_is_left_alone_when_the_helper_runs_from_it() {
+        // The real apply always looks like this, so the delete is skipped rather
+        // than attempted and reported as a failure.
+        let exe = std::env::current_exe().expect("the test binary's own path");
+        assert!(running_from(exe.parent().unwrap()));
+    }
+
+    #[test]
+    fn a_staged_bundle_somewhere_else_is_still_removed() {
+        let fixture = Fixture::new("running-from-elsewhere");
+        assert!(!running_from(&fixture.staged));
     }
 
     #[test]

--- a/packages/plugin/Providers/TrackDataProvider.cs
+++ b/packages/plugin/Providers/TrackDataProvider.cs
@@ -105,7 +105,7 @@ namespace MusicBeePlugin.Providers
                 encoder = string.Empty,
             };
 
-            if (metadataSuccess && metadataResults.Length >= metadataFields.Length)
+            if (metadataSuccess && metadataResults != null && metadataResults.Length >= metadataFields.Length)
             {
                 details.albumArtist = metadataResults[0].Cleanup();
                 details.genre = metadataResults[1].Cleanup();
@@ -365,13 +365,15 @@ namespace MusicBeePlugin.Providers
 
         public LastfmStatus GetNowPlayingLastfmStatus()
         {
+            // Compared literal-first: the tag read is null whenever nothing is loaded,
+            // which is the ordinary state at startup.
             var apiReply = _api.NowPlaying_GetFileTag(Plugin.MetaDataType.RatingLove);
-            if (apiReply.Equals("L", StringComparison.Ordinal) ||
-                apiReply.Equals("lfm", StringComparison.Ordinal) ||
-                apiReply.Equals("Llfm", StringComparison.Ordinal))
+            if ("L".Equals(apiReply, StringComparison.Ordinal) ||
+                "lfm".Equals(apiReply, StringComparison.Ordinal) ||
+                "Llfm".Equals(apiReply, StringComparison.Ordinal))
                 return LastfmStatus.Love;
-            if (apiReply.Equals("B", StringComparison.Ordinal) ||
-                apiReply.Equals("Blfm", StringComparison.Ordinal))
+            if ("B".Equals(apiReply, StringComparison.Ordinal) ||
+                "Blfm".Equals(apiReply, StringComparison.Ordinal))
                 return LastfmStatus.Ban;
             return LastfmStatus.Normal;
         }

--- a/packages/plugin/Utilities/StringCleanupExtension.cs
+++ b/packages/plugin/Utilities/StringCleanupExtension.cs
@@ -10,10 +10,17 @@ namespace MusicBeePlugin.Utilities
         /// <summary>
         ///     Removes control characters from the string and trims whitespace.
         /// </summary>
-        /// <param name="input">The original string</param>
+        /// <remarks>
+        ///     Null in, empty out. This is called directly on MusicBee API returns all over the
+        ///     providers, and the now-playing ones return null whenever nothing is loaded - so a
+        ///     null here is ordinary state, not a bug worth throwing over.
+        /// </remarks>
+        /// <param name="input">The original string, possibly null</param>
         /// <returns>The string with control characters removed and whitespace trimmed.</returns>
         public static string Cleanup(this string input)
         {
+            if (string.IsNullOrEmpty(input)) return string.Empty;
+
             return new string(input.Trim().Where(c => !char.IsControl(c)).ToArray());
         }
     }

--- a/tests/csharp/Providers/TrackNowPlayingNullSafetyTests.cs
+++ b/tests/csharp/Providers/TrackNowPlayingNullSafetyTests.cs
@@ -1,0 +1,89 @@
+using AwesomeAssertions;
+using MusicBeePlugin;
+using MusicBeePlugin.Models;
+using MusicBeePlugin.Providers;
+using Xunit;
+
+namespace MusicBeeRemote.Core.Tests.Providers
+{
+    /// <summary>
+    /// With nothing loaded, MusicBee's now-playing reads return null rather than an
+    /// empty string. Both queries used to dereference that and throw, which showed up
+    /// as a pair of NullReferenceExceptions on every startup with no track (#187).
+    /// </summary>
+    public class TrackNowPlayingNullSafetyTests
+    {
+        /// <summary>
+        /// A MusicBee that has nothing playing: every now-playing read hands back null,
+        /// and the bulk tag read reports success with a null-filled array, which is what
+        /// it does for a loaded track with unset tags.
+        /// </summary>
+        private static Plugin.MusicBeeApiInterface NothingPlaying()
+        {
+            return new Plugin.MusicBeeApiInterface
+            {
+                NowPlaying_GetFileUrl = () => null,
+                NowPlaying_GetFileProperty = _ => null,
+                NowPlaying_GetFileTag = _ => null,
+                NowPlaying_GetFileTags = (Plugin.MetaDataType[] fields, out string[] results) =>
+                {
+                    results = new string[fields.Length];
+                    return true;
+                },
+            };
+        }
+
+        [Fact]
+        public void GetNowPlayingTrackDetails_NothingPlaying_ReturnsEmptyStrings()
+        {
+            var details = new TrackDataProvider(NothingPlaying()).GetNowPlayingTrackDetails();
+
+            details.albumArtist.Should().BeEmpty();
+            details.genre.Should().BeEmpty();
+            details.encoder.Should().BeEmpty();
+            details.kind.Should().BeEmpty();
+            details.duration.Should().BeEmpty();
+            details.dateModified.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetNowPlayingTrackDetails_BulkReadReportsSuccessWithNoArray_ReturnsEmptyStrings()
+        {
+            var api = NothingPlaying();
+            api.NowPlaying_GetFileTags = (Plugin.MetaDataType[] fields, out string[] results) =>
+            {
+                results = null;
+                return true;
+            };
+
+            var details = new TrackDataProvider(api).GetNowPlayingTrackDetails();
+
+            details.albumArtist.Should().BeEmpty();
+            details.comment.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetNowPlayingLastfmStatus_NothingPlaying_IsNormal()
+        {
+            var status = new TrackDataProvider(NothingPlaying()).GetNowPlayingLastfmStatus();
+
+            status.Should().Be(LastfmStatus.Normal);
+        }
+
+        [Theory]
+        [InlineData("L", LastfmStatus.Love)]
+        [InlineData("lfm", LastfmStatus.Love)]
+        [InlineData("Llfm", LastfmStatus.Love)]
+        [InlineData("B", LastfmStatus.Ban)]
+        [InlineData("Blfm", LastfmStatus.Ban)]
+        [InlineData("", LastfmStatus.Normal)]
+        [InlineData("something else", LastfmStatus.Normal)]
+        public void GetNowPlayingLastfmStatus_MapsTheTagValues(string tag, LastfmStatus expected)
+        {
+            var api = NothingPlaying();
+            api.NowPlaying_GetFileTag = _ => tag;
+
+            new TrackDataProvider(api).GetNowPlayingLastfmStatus().Should().Be(expected);
+        }
+    }
+}

--- a/tests/csharp/Utilities/StringCleanupExtensionTests.cs
+++ b/tests/csharp/Utilities/StringCleanupExtensionTests.cs
@@ -202,6 +202,20 @@ namespace MusicBeeRemote.Core.Tests.Utilities
         }
 
         [Fact]
+        public void Cleanup_HandlesNull()
+        {
+            // MusicBee's now-playing reads return null with nothing loaded, and
+            // the providers call this straight on them (#187).
+            string input = null;
+
+            // Act
+            var result = input.Cleanup();
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
         public void Cleanup_HandlesWhitespaceOnlyString()
         {
             // Arrange


### PR DESCRIPTION
Two small fixes found while verifying `v1.5.0-beta.4` on all three install shapes. Both are
log-quality problems: nothing was broken, but a log opened for an unrelated reason opened on
errors that were not errors.

### #187 - now-playing queries throw with nothing playing

`NowPlaying_GetFileTag` / `NowPlaying_GetFileProperty` return null when no track is loaded.
`GetNowPlayingLastfmStatus` called `Equals` on that, and `GetNowPlayingTrackDetails` runs every
property through `Cleanup()`, which dereferenced its input. Two `NullReferenceException`s on
every startup with nothing playing, caught by the core's query boundary and logged.

- `Cleanup()` maps null (and empty) to empty. It is called straight on MusicBee reads all over
  the providers, so this is the right place for it.
- The Last.fm comparison puts the literal first.
- The bulk tag read also guards against a null array behind a `true` return.

New tests drive both queries through a fake API that returns null for every now-playing call,
plus the tag-value mapping and a null case for `Cleanup()`.

### #186 - helper reports a staging directory it cannot delete

The helper runs from `updates/<version>/mbrc-helper.exe`, so Windows will not let it unlink its
own directory and `clear_staged` logged `could not remove ...: Access is denied` on every
successful apply. The core already sweeps that directory on the next start.

It now skips the delete when it is running from that directory and logs what it did instead.
A staging directory somewhere else is still removed, and a failure there is still reported.

### Verification

- `cargo test -p mbrc-helper --target i686-pc-windows-msvc`: 49 passed (2 new).
- `dotnet test`: 83 passed (11 new).
- `cargo clippy --workspace --all-targets --target i686-pc-windows-msvc -- -D warnings`: clean.
- `dotnet format --verify-no-changes`: clean.

Not run live yet: the helper path needs a real apply, which the GA hop will exercise.

Closes #186
Closes #187
