### PR TITLE
fix(installer): make the uninstaller remove the plugin it installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ shipped Android and iOS client keeps working untouched.
   already recovered.
 - A MusicBee too old for the plugin now says so, in the plugin list and in a log
   file, instead of loading and silently doing nothing.
+- The installer's uninstaller removed nothing. It looked for the plugin files one
+  directory deeper than they are, so every delete missed, and it still reported
+  that the plugin had been removed. Removing the plugin inside MusicBee instead
+  leaves `mbrc_core.dll` and `mbrc-helper.exe` behind, since MusicBee only knows
+  about the file it loaded - delete those two by hand, or use the uninstaller
+  (#192).
 - Single-file albums split by a `.cue` sheet showed in the now-playing list as a
   row of "Unknown Artist" per track. Every such track reports the same container
   file, so reading tags by file returned nothing for all of them; the list now

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ Use this method for the Microsoft Store version of MusicBee or if you prefer man
 
 After installation, the plugin should appear in MusicBee under `Edit > Preferences > Plugins`.
 
+### Uninstalling
+
+If you installed with the installer, use `Uninstall MusicBee Remote` from the Start
+Menu (or `mbremoteuninstall.exe` in MusicBee's `Plugins` folder). It removes all
+three files and the plugin's stored settings, caches and logs.
+
+If you installed from the zip, remove the plugin in MusicBee under
+`Edit > Preferences > Plugins`. That deletes the plugin's stored data straight away,
+and MusicBee deletes `mb_remote.dll` itself the next time it starts. `mbrc_core.dll`
+and `mbrc-helper.exe` are left behind - MusicBee only knows about the assembly it
+loaded - so delete those two from the `Plugins` folder yourself ([#192][issue-192]).
+
+[issue-192]: https://github.com/musicbeeremote/mbrc-plugin/issues/192
+
 ## Getting Started
 
 As a developer there are a few steps you need to follow to get started:

--- a/installer/MusicBeeRemote.nsi
+++ b/installer/MusicBeeRemote.nsi
@@ -118,14 +118,18 @@ Function un.onInit
 FunctionEnd
 
 Section Uninstall
-	; Plugin files live under $INSTDIR\Plugins (see SetOutPath above).
-	Delete "$INSTDIR\Plugins\mb_remote.dll"
-	Delete "$INSTDIR\Plugins\mbrc_core.dll"
-	Delete "$INSTDIR\Plugins\mbrc-helper.exe"
+	; $INSTDIR is NOT what it was during install. The uninstaller was written to
+	; $INSTDIR\Plugins, and an uninstaller initialises $INSTDIR to the directory it
+	; lives in, so here $INSTDIR is the plugins directory itself. Prefixing these
+	; with Plugins\ again pointed every delete at a directory that does not exist,
+	; and the uninstall removed nothing while still reporting success.
+	Delete "$INSTDIR\mb_remote.dll"
+	Delete "$INSTDIR\mbrc_core.dll"
+	Delete "$INSTDIR\mbrc-helper.exe"
 	; Also clear the pre-1.5.0 C# utility, in case this uninstall follows an
 	; upgrade from an install that had it.
-	Delete "$INSTDIR\Plugins\firewall-utility.exe"
-	Delete "$INSTDIR\Plugins\mbremoteuninstall.exe"
+	Delete "$INSTDIR\firewall-utility.exe"
+	Delete "$INSTDIR\mbremoteuninstall.exe"
 	RmDir /r "$APPDATA\MusicBee\mb_remote"
 
 	; Remove Start Menu items


### PR DESCRIPTION
Running `mbremoteuninstall.exe` on a real Program Files install removed the Start Menu shortcut
and `%APPDATA%\MusicBee\mb_remote`, left all three plugin files and the uninstaller itself in
place, and reported that the plugin was successfully removed.

## Cause

The uninstaller is written to `$INSTDIR\Plugins\mbremoteuninstall.exe`, and an NSIS uninstaller
initialises `$INSTDIR` to the directory it lives in. At uninstall time `$INSTDIR` is therefore
already the plugins directory, but every delete still prefixed `Plugins\` on top of it, so they
all pointed at `MusicBee\Plugins\Plugins\...`. `Delete` on a missing path is not an error, so
the section ran to completion and `un.onUninstSuccess` claimed success.

The two lines that used absolute paths (`$APPDATA`, `$SMPROGRAMS`) are the only two that did
anything, which is why the symptom is "data and shortcut gone, plugin still installed".

## Fix

Drop the extra `Plugins\` from the five deletes and say in a comment why `$INSTDIR` differs
between the install and uninstall sections, since that is the whole trap.

## Verification

Installer rebuilt locally from the fixed script (`makensis`, stamped `1.5.0-rc.1`) - a live
install/uninstall cycle on the Program Files install is running separately; this PR will not be
merged before that passes.
