### PR TITLE
feat(uninstall): remove the plugin files MusicBee leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ shipped Android and iOS client keeps working untouched.
   already recovered.
 - A MusicBee too old for the plugin now says so, in the plugin list and in a log
   file, instead of loading and silently doing nothing.
+- Uninstalling removes everything the plugin installed. The installer's
+  uninstaller looked for the files one directory too deep and so deleted none of
+  them while reporting success, and removing the plugin inside MusicBee left
+  `mbrc_core.dll` and `mbrc-helper.exe` behind - MusicBee only knows about
+  `mb_remote.dll`. The plugin now has the helper remove them once MusicBee exits,
+  and leaves them alone if the plugin is installed again in the meantime.
 - Single-file albums split by a `.cue` sheet showed in the now-playing list as a
   row of "Unknown Artist" per track. Every such track reports the same container
   file, so reading tags by file returned nothing for all of them; the list now

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ Use this method for the Microsoft Store version of MusicBee or if you prefer man
 
 After installation, the plugin should appear in MusicBee under `Edit > Preferences > Plugins`.
 
+### Uninstalling
+
+If you installed with the installer, use `Uninstall MusicBee Remote` from the Start
+Menu (or `mbremoteuninstall.exe` in MusicBee's `Plugins` folder). It removes all
+three files and the plugin's stored settings, caches and logs.
+
+If you installed from the zip, remove the plugin in MusicBee under
+`Edit > Preferences > Plugins`. MusicBee deletes `mb_remote.dll` - the only file it
+knows about - so the plugin also asks `mbrc-helper.exe` to remove `mbrc_core.dll`
+and itself once MusicBee exits; the core is loaded into MusicBee and cannot be
+deleted before then. That cleanup runs as you, without an elevation prompt, so on
+an install in a directory that needs administrator rights it does nothing and the
+installer's uninstaller is the route to use.
+
 ## Getting Started
 
 As a developer there are a few steps you need to follow to get started:

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -362,18 +362,25 @@ pub extern "C" fn mbrc_apply_staged_update() -> c_int {
 /// and only if the plugin is still gone at that point, so adding it back in the
 /// same session is safe.
 ///
-/// Takes nothing, for the same reason as `mbrc_apply_staged_update`: the
-/// directory is where this DLL was loaded from and the pid is our own, so there
-/// is nothing for a caller to name and nothing to tamper with.
+/// The directory to remove files from is where this DLL was loaded from and the
+/// pid is our own, so neither is a parameter - there is nothing for a caller to
+/// name and nothing to tamper with. `storage_path` is: it is only read for
+/// whether it exists, which is how the helper tells "removed" from "removed and
+/// added straight back", and the worst a wrong value can do is call the removal
+/// off.
+///
+/// # Safety
+/// `storage_path` must be null or a valid NUL-terminated C string.
 ///
 /// Returns 1 if a cleanup was started, 0 otherwise - including the ordinary case
 /// of a plugins directory that needs elevation, where the installer's uninstaller
 /// is the route that removes these files. Never fails: a plugin being removed is
 /// not a moment to raise an error the user cannot act on.
 #[no_mangle]
-pub extern "C" fn mbrc_request_plugin_cleanup() -> c_int {
+pub unsafe extern "C" fn mbrc_request_plugin_cleanup(storage_path: *const c_char) -> c_int {
     ffi_guard("mbrc_request_plugin_cleanup", || {
-        c_int::from(updates::elevate::request_plugin_cleanup())
+        let storage_path = unsafe { cstr(storage_path) };
+        c_int::from(updates::elevate::request_plugin_cleanup(&storage_path))
     })
 }
 

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -353,6 +353,30 @@ pub extern "C" fn mbrc_apply_staged_update() -> c_int {
     )
 }
 
+/// Remove the plugin files a MusicBee-side uninstall leaves behind.
+///
+/// MusicBee deletes `mb_remote.dll` when the user removes the plugin from
+/// Preferences and knows nothing about `mbrc_core.dll` and `mbrc-helper.exe`
+/// beside it. This core cannot delete itself while it is loaded, so it starts a
+/// copy of the helper that waits for MusicBee to exit and removes them then -
+/// and only if the plugin is still gone at that point, so adding it back in the
+/// same session is safe.
+///
+/// Takes nothing, for the same reason as `mbrc_apply_staged_update`: the
+/// directory is where this DLL was loaded from and the pid is our own, so there
+/// is nothing for a caller to name and nothing to tamper with.
+///
+/// Returns 1 if a cleanup was started, 0 otherwise - including the ordinary case
+/// of a plugins directory that needs elevation, where the installer's uninstaller
+/// is the route that removes these files. Never fails: a plugin being removed is
+/// not a moment to raise an error the user cannot act on.
+#[no_mangle]
+pub extern "C" fn mbrc_request_plugin_cleanup() -> c_int {
+    ffi_guard("mbrc_request_plugin_cleanup", || {
+        c_int::from(updates::elevate::request_plugin_cleanup())
+    })
+}
+
 /// Free a string previously returned to C# by the core. Null-safe. This is the
 /// only Rust-owned allocation the C# side frees through us.
 ///

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -114,6 +114,67 @@ pub fn launch(storage_path: &str, current_version: &str) -> UpdateLaunch {
     outcome
 }
 
+/// Asks the helper to remove what a plugin uninstall cannot remove itself.
+///
+/// MusicBee removes `mb_remote.dll` when the user removes the plugin, and knows
+/// nothing about `mbrc_core.dll` or `mbrc-helper.exe` beside it. This DLL cannot
+/// remove itself either - it is mapped into the process making the call - so the
+/// helper is copied to a temp directory and the copy is started there. It waits
+/// for MusicBee to exit and then removes the originals, itself included.
+///
+/// Deliberately never elevates. A plugins directory that needs administrator
+/// rights belongs to an install that came from the installer, and its own
+/// uninstaller removes these files; prompting for UAC in the middle of a plugin
+/// removal would be a surprise the user did not ask for. So a non-writable
+/// directory is a quiet no, recorded in the log.
+///
+/// Returns whether a cleanup was started. Nothing depends on the answer beyond
+/// the log line: by the time it matters this process is gone.
+pub fn request_plugin_cleanup() -> bool {
+    let Some(target) = plugins_dir() else {
+        tracing::warn!("cannot clean up: the plugins directory is unknown");
+        return false;
+    };
+    let helper = target.join(HELPER_EXE);
+    if !helper.is_file() {
+        tracing::info!(
+            target = %target.display(),
+            "no helper to clean up with; leaving the plugin files in place"
+        );
+        return false;
+    }
+    if !is_writable(&target) {
+        tracing::info!(
+            target = %target.display(),
+            "the plugins directory needs elevation; leaving these files to the uninstaller"
+        );
+        return false;
+    }
+
+    // Named for this process so two MusicBees uninstalling at once do not fight
+    // over one file. Left behind in temp on purpose: a running image cannot
+    // unlink itself, and temp is where a stray copy belongs.
+    let copy = std::env::temp_dir().join(format!("mbrc-cleanup-{}.exe", std::process::id()));
+    if let Err(e) = std::fs::copy(&helper, &copy) {
+        tracing::warn!(error = %e, copy = %copy.display(), "could not stage the cleanup helper");
+        return false;
+    }
+
+    let arguments = vec![
+        "cleanup".to_owned(),
+        "--pid".to_owned(),
+        std::process::id().to_string(),
+        "--target".to_owned(),
+        target.display().to_string(),
+    ];
+    tracing::info!(
+        helper = %copy.display(),
+        target = %target.display(),
+        "starting the plugin cleanup helper"
+    );
+    matches!(spawn(&copy, &arguments, false), UpdateLaunch::Launched)
+}
+
 /// Whether `staged` is newer than what is installed.
 ///
 /// Unparseable on either side is not an upgrade: a version that cannot be

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -128,9 +128,18 @@ pub fn launch(storage_path: &str, current_version: &str) -> UpdateLaunch {
 /// removal would be a surprise the user did not ask for. So a non-writable
 /// directory is a quiet no, recorded in the log.
 ///
+/// `storage_path` is the directory the uninstall just deleted - the signal the
+/// helper uses to tell "removed" from "removed and added straight back", since
+/// MusicBee defers deleting `mb_remote.dll` to its next start and that file is
+/// therefore no signal at all.
+///
 /// Returns whether a cleanup was started. Nothing depends on the answer beyond
 /// the log line: by the time it matters this process is gone.
-pub fn request_plugin_cleanup() -> bool {
+pub fn request_plugin_cleanup(storage_path: &str) -> bool {
+    if storage_path.is_empty() {
+        tracing::warn!("cannot clean up: the storage directory is unknown");
+        return false;
+    }
     let Some(target) = plugins_dir() else {
         tracing::warn!("cannot clean up: the plugins directory is unknown");
         return false;
@@ -166,6 +175,13 @@ pub fn request_plugin_cleanup() -> bool {
         std::process::id().to_string(),
         "--target".to_owned(),
         target.display().to_string(),
+        // Read only for whether it exists. The uninstall deleted it, so a
+        // storage directory that is back means the plugin loaded again and
+        // nothing is to be removed. Taken from the caller because MusicBee is
+        // the authority on where it is - and unlike the target, the worst a
+        // wrong value can do is call the removal off.
+        "--storage".to_owned(),
+        storage_path.to_owned(),
     ];
     tracing::info!(
         helper = %copy.display(),

--- a/packages/mbrc-helper/src/cleanup.rs
+++ b/packages/mbrc-helper/src/cleanup.rs
@@ -1,0 +1,275 @@
+//! Removing the files a plugin uninstall cannot remove itself.
+//!
+//! When the user removes the plugin from MusicBee's Preferences, MusicBee
+//! deletes `mb_remote.dll` - the assembly it loaded - and nothing else. It has
+//! never heard of `mbrc_core.dll` or `mbrc-helper.exe`, which sit beside it as
+//! ordinary files, so both are left behind. The plugin cannot delete the core
+//! itself either: it is mapped into MusicBee for as long as MusicBee is running,
+//! and Windows will not unlink a loaded image.
+//!
+//! So the core copies this helper to a temp directory and starts the copy, which
+//! waits for MusicBee to exit and then removes what is left. Unelevated, as the
+//! user: if the plugins directory needs administrator rights, the install came
+//! from the installer and its uninstaller is the route that removes these files.
+//! There is no privilege boundary here and so nothing to verify - unlike the
+//! update path, this helper is neither elevated nor acting on a downloaded
+//! bundle.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::update::{checked_dir, wait_for_exit, Error, Result};
+
+/// How long to wait for MusicBee to exit before giving up.
+///
+/// Longer than the update path's two minutes: nothing is pending and nobody is
+/// watching. The user removed the plugin and may well keep MusicBee open for the
+/// rest of the evening, and a cleanup that gives up after two minutes would be
+/// wrong far more often than it was right.
+const EXIT_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
+/// What the plugin leaves behind, in the order they are removed.
+///
+/// `mb_remote.dll` is deliberately absent: it is MusicBee's to delete, and its
+/// presence is what tells us the removal did not stick (see [`run`]).
+const LEFTOVERS: &[&str] = &[
+    "mbrc_core.dll",
+    // The pre-1.5.0 C# utility this helper replaced. Only present on an install
+    // that was upgraded rather than installed fresh.
+    "firewall-utility.exe",
+    // Last: this is the file the caller copied to run us, or the one we are
+    // running from when someone invokes this by hand.
+    "mbrc-helper.exe",
+];
+
+/// The file whose absence means the plugin really was removed.
+const PLUGIN_DLL: &str = "mb_remote.dll";
+
+pub struct Request<'a> {
+    pub pid: u32,
+    pub target: &'a str,
+}
+
+#[derive(Debug)]
+pub struct Plan {
+    pub pid: u32,
+    pub target: PathBuf,
+}
+
+/// What happened, for the log and the exit code.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// Files removed. Empty is not reachable here - see `NothingToRemove`.
+    Removed(Vec<String>),
+    /// `mb_remote.dll` is back: the plugin was reinstalled, or MusicBee never
+    /// removed it. Either way these files are in use again and are not ours to
+    /// delete.
+    StillInstalled,
+    /// Nothing of ours is in the directory any more.
+    NothingToRemove,
+    /// MusicBee outlived the wait. Nothing was touched.
+    StillRunning,
+    /// Some files could not be removed, with the reasons.
+    Partial {
+        removed: Vec<String>,
+        failed: Vec<String>,
+    },
+}
+
+pub fn plan(request: &Request<'_>) -> Result<Plan> {
+    let target = checked_dir(request.target, "--target")?;
+    // A directory with no plugin of ours in it is a caller bug, and this process
+    // deletes files: it does not act on a directory it cannot recognise.
+    if !LEFTOVERS.iter().any(|name| target.join(name).exists()) && !target.join(PLUGIN_DLL).exists()
+    {
+        return Err(Error::Rejected(format!(
+            "{} holds no MusicBee Remote files",
+            target.display()
+        )));
+    }
+    Ok(Plan {
+        pid: request.pid,
+        target,
+    })
+}
+
+/// Waits for MusicBee to exit, then removes what the uninstall left behind.
+pub fn run(plan: &Plan) -> Outcome {
+    run_with(plan, wait_for_exit)
+}
+
+/// The seam the tests drive: the wait is injected so the removal can be
+/// exercised without a process to wait for.
+pub fn run_with(plan: &Plan, wait: fn(u32, Duration) -> bool) -> Outcome {
+    if !wait(plan.pid, EXIT_TIMEOUT) {
+        return Outcome::StillRunning;
+    }
+
+    // Re-checked after the wait, not before: the window between the user
+    // removing the plugin and MusicBee exiting is exactly when they might add it
+    // back, and deleting the core out from under a reinstalled plugin would
+    // break an install that was working a moment ago.
+    if plan.target.join(PLUGIN_DLL).exists() {
+        return Outcome::StillInstalled;
+    }
+
+    let mut removed = Vec::new();
+    let mut failed = Vec::new();
+    for name in LEFTOVERS {
+        let path = plan.target.join(name);
+        if !path.exists() {
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => removed.push((*name).to_owned()),
+            Err(e) => failed.push(format!("{name}: {e}")),
+        }
+    }
+
+    match (removed.is_empty(), failed.is_empty()) {
+        (true, true) => Outcome::NothingToRemove,
+        (_, false) => Outcome::Partial { removed, failed },
+        (false, true) => Outcome::Removed(removed),
+    }
+}
+
+/// Whether this process is running from `dir`, which decides whether it can
+/// remove itself. Only used to say so in the log: the removal is attempted
+/// either way, and Windows refusing to unlink a running image is reported like
+/// any other failure.
+pub fn running_from(dir: &Path) -> bool {
+    crate::update::running_from(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(name: &str) -> Self {
+            let root = std::env::temp_dir().join(format!("mbrc-cleanup-{name}"));
+            let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn write(&self, name: &str) {
+            std::fs::write(self.root.join(name), b"stand-in").unwrap();
+        }
+
+        fn plan(&self) -> Plan {
+            Plan {
+                pid: 1,
+                target: std::fs::canonicalize(&self.root).unwrap(),
+            }
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn gone(_pid: u32, _timeout: Duration) -> bool {
+        true
+    }
+
+    fn still_running(_pid: u32, _timeout: Duration) -> bool {
+        false
+    }
+
+    #[test]
+    fn removes_what_musicbee_leaves_behind() {
+        let fixture = Fixture::new("removes");
+        fixture.write("mbrc_core.dll");
+        fixture.write("mbrc-helper.exe");
+
+        let outcome = run_with(&fixture.plan(), gone);
+
+        assert_eq!(
+            outcome,
+            Outcome::Removed(vec!["mbrc_core.dll".into(), "mbrc-helper.exe".into()])
+        );
+        assert!(!fixture.root.join("mbrc_core.dll").exists());
+        assert!(!fixture.root.join("mbrc-helper.exe").exists());
+    }
+
+    #[test]
+    fn removes_the_retired_firewall_utility_too() {
+        let fixture = Fixture::new("retired");
+        fixture.write("mbrc_core.dll");
+        fixture.write("firewall-utility.exe");
+
+        let outcome = run_with(&fixture.plan(), gone);
+
+        assert_eq!(
+            outcome,
+            Outcome::Removed(vec!["mbrc_core.dll".into(), "firewall-utility.exe".into()])
+        );
+    }
+
+    #[test]
+    fn a_reinstalled_plugin_is_left_alone() {
+        let fixture = Fixture::new("reinstalled");
+        fixture.write("mbrc_core.dll");
+        fixture.write("mbrc-helper.exe");
+        // Added back between the removal and MusicBee exiting.
+        fixture.write("mb_remote.dll");
+
+        assert_eq!(run_with(&fixture.plan(), gone), Outcome::StillInstalled);
+        assert!(fixture.root.join("mbrc_core.dll").exists());
+    }
+
+    #[test]
+    fn a_musicbee_that_outlives_the_wait_changes_nothing() {
+        let fixture = Fixture::new("still-running");
+        fixture.write("mbrc_core.dll");
+
+        assert_eq!(
+            run_with(&fixture.plan(), still_running),
+            Outcome::StillRunning
+        );
+        assert!(fixture.root.join("mbrc_core.dll").exists());
+    }
+
+    #[test]
+    fn an_already_clean_directory_is_not_a_failure() {
+        let fixture = Fixture::new("clean");
+        assert_eq!(run_with(&fixture.plan(), gone), Outcome::NothingToRemove);
+    }
+
+    #[test]
+    fn a_directory_with_nothing_of_ours_is_refused() {
+        let fixture = Fixture::new("not-ours");
+        fixture.write("mb_TheaterModePlugin.dll");
+
+        let target = fixture.root.to_string_lossy().to_string();
+        let error = plan(&Request {
+            pid: 1,
+            target: &target,
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, Error::Rejected(_)), "{error}");
+    }
+
+    #[test]
+    fn a_directory_holding_only_the_plugin_is_accepted() {
+        // The plugin is still there when the core asks for the cleanup - MusicBee
+        // removes it as part of the same teardown - so this has to be allowed.
+        let fixture = Fixture::new("plugin-only");
+        fixture.write("mb_remote.dll");
+
+        let target = fixture.root.to_string_lossy().to_string();
+        assert!(plan(&Request {
+            pid: 1,
+            target: &target,
+        })
+        .is_ok());
+    }
+}

--- a/packages/mbrc-helper/src/cleanup.rs
+++ b/packages/mbrc-helper/src/cleanup.rs
@@ -22,11 +22,20 @@ use crate::update::{checked_dir, wait_for_exit, Error, Result};
 
 /// How long to wait for MusicBee to exit before giving up.
 ///
-/// Longer than the update path's two minutes: nothing is pending and nobody is
-/// watching. The user removed the plugin and may well keep MusicBee open for the
-/// rest of the evening, and a cleanup that gives up after two minutes would be
-/// wrong far more often than it was right.
-const EXIT_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+/// Longer than the update path's two minutes, because nothing is pending and the
+/// user may well finish the album they are listening to first. Not much longer:
+/// a copy of an executable sitting in the temp directory waiting on a process is
+/// indistinguishable from something malicious, and the first time this ran on a
+/// real machine it was killed on sight - correctly. Fifteen minutes covers
+/// "removed the plugin and closed MusicBee", which is the case worth covering,
+/// and the cost of missing the rest is two files a reinstall overwrites anyway.
+const EXIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// How often to say we are still here while waiting.
+///
+/// The log is the only thing this process can use to account for itself, and
+/// "started, then silence for a quarter of an hour" is what made it look stuck.
+const HEARTBEAT: Duration = Duration::from_secs(3 * 60);
 
 /// What the plugin leaves behind, in the order they are removed.
 ///
@@ -101,9 +110,15 @@ pub fn run(plan: &Plan) -> Outcome {
 /// The seam the tests drive: the wait is injected so the removal can be
 /// exercised without a process to wait for.
 pub fn run_with(plan: &Plan, wait: fn(u32, Duration) -> bool) -> Outcome {
-    if !wait(plan.pid, EXIT_TIMEOUT) {
+    crate::log::line(&format!(
+        "waiting up to {} minutes for MusicBee (pid {}) to exit; nothing can be removed until it does",
+        EXIT_TIMEOUT.as_secs() / 60,
+        plan.pid
+    ));
+    if !wait_for_musicbee(plan.pid, wait) {
         return Outcome::StillRunning;
     }
+    crate::log::line("MusicBee exited; removing what the uninstall left behind");
 
     // Re-checked after the wait, not before: the window between the user
     // removing the plugin and MusicBee exiting is exactly when they might add it
@@ -131,6 +146,27 @@ pub fn run_with(plan: &Plan, wait: fn(u32, Duration) -> bool) -> Outcome {
         (_, false) => Outcome::Partial { removed, failed },
         (false, true) => Outcome::Removed(removed),
     }
+}
+
+/// Waits for MusicBee, saying so as it goes.
+///
+/// Split into heartbeat-sized slices rather than one long wait purely so the log
+/// shows the process is alive and why. `true` means MusicBee is gone.
+fn wait_for_musicbee(pid: u32, wait: fn(u32, Duration) -> bool) -> bool {
+    let mut waited = Duration::ZERO;
+    while waited < EXIT_TIMEOUT {
+        let slice = HEARTBEAT.min(EXIT_TIMEOUT - waited);
+        if wait(pid, slice) {
+            return true;
+        }
+        waited += slice;
+        crate::log::line(&format!(
+            "still waiting for MusicBee (pid {pid}); {} of {} minutes elapsed",
+            waited.as_secs() / 60,
+            EXIT_TIMEOUT.as_secs() / 60
+        ));
+    }
+    false
 }
 
 /// Whether this process is running from `dir`, which decides whether it can

--- a/packages/mbrc-helper/src/cleanup.rs
+++ b/packages/mbrc-helper/src/cleanup.rs
@@ -7,8 +7,12 @@
 //! itself either: it is mapped into MusicBee for as long as MusicBee is running,
 //! and Windows will not unlink a loaded image.
 //!
+//! MusicBee also defers deleting `mb_remote.dll` to its *next* start, so at the
+//! moment this runs the plugin file is still there whatever the user did.
+//!
 //! So the core copies this helper to a temp directory and starts the copy, which
-//! waits for MusicBee to exit and then removes what is left. Unelevated, as the
+//! waits for MusicBee to exit and then removes what is left, `mb_remote.dll`
+//! included - MusicBee deleting a file that is already gone is not a problem. Unelevated, as the
 //! user: if the plugins directory needs administrator rights, the install came
 //! from the installer and its uninstaller is the route that removes these files.
 //! There is no privilege boundary here and so nothing to verify - unlike the
@@ -39,9 +43,12 @@ const HEARTBEAT: Duration = Duration::from_secs(3 * 60);
 
 /// What the plugin leaves behind, in the order they are removed.
 ///
-/// `mb_remote.dll` is deliberately absent: it is MusicBee's to delete, and its
-/// presence is what tells us the removal did not stick (see [`run`]).
+/// `mb_remote.dll` is in the list even though MusicBee deletes it too: MusicBee
+/// only does so at its next start, which may be days away or never, and until
+/// then a plugins directory with a plugin DLL in it is one MusicBee will try to
+/// load a core for that is no longer there.
 const LEFTOVERS: &[&str] = &[
+    "mb_remote.dll",
     "mbrc_core.dll",
     // The pre-1.5.0 C# utility this helper replaced. Only present on an install
     // that was upgraded rather than installed fresh.
@@ -51,18 +58,19 @@ const LEFTOVERS: &[&str] = &[
     "mbrc-helper.exe",
 ];
 
-/// The file whose absence means the plugin really was removed.
-const PLUGIN_DLL: &str = "mb_remote.dll";
-
 pub struct Request<'a> {
     pub pid: u32,
     pub target: &'a str,
+    pub storage: &'a str,
 }
 
 #[derive(Debug)]
 pub struct Plan {
     pub pid: u32,
     pub target: PathBuf,
+    /// The plugin's storage directory, which the uninstall deleted on its way
+    /// out. Read only for whether it exists - see [`run_with`].
+    pub storage: PathBuf,
 }
 
 /// What happened, for the log and the exit code.
@@ -89,8 +97,7 @@ pub fn plan(request: &Request<'_>) -> Result<Plan> {
     let target = checked_dir(request.target, "--target")?;
     // A directory with no plugin of ours in it is a caller bug, and this process
     // deletes files: it does not act on a directory it cannot recognise.
-    if !LEFTOVERS.iter().any(|name| target.join(name).exists()) && !target.join(PLUGIN_DLL).exists()
-    {
+    if !LEFTOVERS.iter().any(|name| target.join(name).exists()) {
         return Err(Error::Rejected(format!(
             "{} holds no MusicBee Remote files",
             target.display()
@@ -99,7 +106,30 @@ pub fn plan(request: &Request<'_>) -> Result<Plan> {
     Ok(Plan {
         pid: request.pid,
         target,
+        storage: checked_storage(request.storage)?,
     })
+}
+
+/// The storage directory argument, which unlike the others is expected *not* to
+/// exist: the uninstall deleted it moments before this process started. So the
+/// path is checked by its shape rather than by resolving it, and it is never
+/// written to or deleted - only tested for existence.
+fn checked_storage(raw: &str) -> Result<PathBuf> {
+    if raw.trim().is_empty() {
+        return Err(Error::Rejected("--storage is empty".into()));
+    }
+    let path = Path::new(raw);
+    if !path.is_absolute() {
+        return Err(Error::Rejected(format!(
+            "--storage {raw:?} is not absolute"
+        )));
+    }
+    if raw.starts_with("\\\\") || raw.starts_with("//") {
+        return Err(Error::Rejected(format!(
+            "--storage {raw:?} is a network path"
+        )));
+    }
+    Ok(path.to_path_buf())
 }
 
 /// Waits for MusicBee to exit, then removes what the uninstall left behind.
@@ -118,15 +148,22 @@ pub fn run_with(plan: &Plan, wait: fn(u32, Duration) -> bool) -> Outcome {
     if !wait_for_musicbee(plan.pid, wait) {
         return Outcome::StillRunning;
     }
-    crate::log::line("MusicBee exited; removing what the uninstall left behind");
+    crate::log::line("MusicBee exited");
 
-    // Re-checked after the wait, not before: the window between the user
-    // removing the plugin and MusicBee exiting is exactly when they might add it
-    // back, and deleting the core out from under a reinstalled plugin would
-    // break an install that was working a moment ago.
-    if plan.target.join(PLUGIN_DLL).exists() {
+    // The re-add check, and it is the storage directory rather than the plugin
+    // DLL because only one of the two is a signal. MusicBee defers deleting
+    // `mb_remote.dll` to its next start, so that file is still there whatever
+    // the user did; the storage directory was deleted by the uninstall and only
+    // a plugin that loaded again would have recreated it.
+    //
+    // Checked after the wait, not before: the window between removing the plugin
+    // and MusicBee exiting is exactly when someone might add it back, and
+    // deleting the core out from under a working install is the one outcome
+    // worth this much care.
+    if plan.storage.exists() {
         return Outcome::StillInstalled;
     }
+    crate::log::line("removing what the uninstall left behind");
 
     let mut removed = Vec::new();
     let mut failed = Vec::new();
@@ -183,24 +220,39 @@ mod tests {
 
     struct Fixture {
         root: PathBuf,
+        /// The plugins directory, and beside it the storage directory the
+        /// uninstall would have deleted.
+        plugins: PathBuf,
+        storage: PathBuf,
     }
 
     impl Fixture {
         fn new(name: &str) -> Self {
             let root = std::env::temp_dir().join(format!("mbrc-cleanup-{name}"));
             let _ = std::fs::remove_dir_all(&root);
-            std::fs::create_dir_all(&root).unwrap();
-            Self { root }
+            let plugins = root.join("Plugins");
+            std::fs::create_dir_all(&plugins).unwrap();
+            Self {
+                storage: root.join("mb_remote"),
+                plugins,
+                root,
+            }
         }
 
         fn write(&self, name: &str) {
-            std::fs::write(self.root.join(name), b"stand-in").unwrap();
+            std::fs::write(self.plugins.join(name), b"stand-in").unwrap();
+        }
+
+        /// The plugin loaded again and recreated its storage.
+        fn reinstalled(&self) {
+            std::fs::create_dir_all(&self.storage).unwrap();
         }
 
         fn plan(&self) -> Plan {
             Plan {
                 pid: 1,
-                target: std::fs::canonicalize(&self.root).unwrap(),
+                target: std::fs::canonicalize(&self.plugins).unwrap(),
+                storage: self.storage.clone(),
             }
         }
     }
@@ -222,6 +274,9 @@ mod tests {
     #[test]
     fn removes_what_musicbee_leaves_behind() {
         let fixture = Fixture::new("removes");
+        // MusicBee defers deleting its own file to the next start, so this is
+        // exactly what the directory looks like when the helper wakes up.
+        fixture.write("mb_remote.dll");
         fixture.write("mbrc_core.dll");
         fixture.write("mbrc-helper.exe");
 
@@ -229,10 +284,16 @@ mod tests {
 
         assert_eq!(
             outcome,
-            Outcome::Removed(vec!["mbrc_core.dll".into(), "mbrc-helper.exe".into()])
+            Outcome::Removed(vec![
+                "mb_remote.dll".into(),
+                "mbrc_core.dll".into(),
+                "mbrc-helper.exe".into()
+            ])
         );
-        assert!(!fixture.root.join("mbrc_core.dll").exists());
-        assert!(!fixture.root.join("mbrc-helper.exe").exists());
+        assert!(std::fs::read_dir(&fixture.plugins)
+            .unwrap()
+            .next()
+            .is_none());
     }
 
     #[test]
@@ -252,13 +313,30 @@ mod tests {
     #[test]
     fn a_reinstalled_plugin_is_left_alone() {
         let fixture = Fixture::new("reinstalled");
+        fixture.write("mb_remote.dll");
         fixture.write("mbrc_core.dll");
         fixture.write("mbrc-helper.exe");
-        // Added back between the removal and MusicBee exiting.
-        fixture.write("mb_remote.dll");
+        // Added back between the removal and MusicBee exiting: the plugin loaded
+        // again and recreated the storage the uninstall had deleted.
+        fixture.reinstalled();
 
         assert_eq!(run_with(&fixture.plan(), gone), Outcome::StillInstalled);
-        assert!(fixture.root.join("mbrc_core.dll").exists());
+        assert!(fixture.plugins.join("mbrc_core.dll").exists());
+    }
+
+    #[test]
+    fn the_plugin_dll_alone_is_not_read_as_a_reinstall() {
+        // The case that made the first design wrong: MusicBee had not yet
+        // deleted its own file, and taking that as "installed again" meant the
+        // cleanup could never run at all.
+        let fixture = Fixture::new("deferred-delete");
+        fixture.write("mb_remote.dll");
+        fixture.write("mbrc_core.dll");
+
+        assert!(matches!(
+            run_with(&fixture.plan(), gone),
+            Outcome::Removed(_)
+        ));
     }
 
     #[test]
@@ -270,7 +348,7 @@ mod tests {
             run_with(&fixture.plan(), still_running),
             Outcome::StillRunning
         );
-        assert!(fixture.root.join("mbrc_core.dll").exists());
+        assert!(fixture.plugins.join("mbrc_core.dll").exists());
     }
 
     #[test]
@@ -284,10 +362,12 @@ mod tests {
         let fixture = Fixture::new("not-ours");
         fixture.write("mb_TheaterModePlugin.dll");
 
-        let target = fixture.root.to_string_lossy().to_string();
+        let target = fixture.plugins.to_string_lossy().to_string();
+        let storage = fixture.storage.to_string_lossy().to_string();
         let error = plan(&Request {
             pid: 1,
             target: &target,
+            storage: &storage,
         })
         .unwrap_err();
 
@@ -296,15 +376,17 @@ mod tests {
 
     #[test]
     fn a_directory_holding_only_the_plugin_is_accepted() {
-        // The plugin is still there when the core asks for the cleanup - MusicBee
-        // removes it as part of the same teardown - so this has to be allowed.
+        // The plugin file is always still there when the cleanup is asked for:
+        // MusicBee deletes it at its next start, not now.
         let fixture = Fixture::new("plugin-only");
         fixture.write("mb_remote.dll");
 
-        let target = fixture.root.to_string_lossy().to_string();
+        let target = fixture.plugins.to_string_lossy().to_string();
+        let storage = fixture.storage.to_string_lossy().to_string();
         assert!(plan(&Request {
             pid: 1,
             target: &target,
+            storage: &storage,
         })
         .is_ok());
     }

--- a/packages/mbrc-helper/src/log.rs
+++ b/packages/mbrc-helper/src/log.rs
@@ -48,6 +48,18 @@ pub fn direct_to_storage(staged: &Path) {
     *sink() = choose_sink(staged, &std::env::temp_dir());
 }
 
+/// Point the log at the temp directory.
+///
+/// For `cleanup`, which has no storage directory to sit beside: the plugin
+/// deletes its storage as part of the same uninstall, so the only place left
+/// that is certain to be writable is temp. The file is the same
+/// `mbrc-helper.log`, so a cleanup that went wrong is still readable next to a
+/// pasted log rather than nowhere at all.
+pub fn direct_to_temp() {
+    let path = std::env::temp_dir().join(LOG_FILE);
+    *sink() = writable(&path).then_some(path);
+}
+
 /// Records where this process actually is, which is the question every
 /// Store-install failure has turned on.
 ///

--- a/packages/mbrc-helper/src/main.rs
+++ b/packages/mbrc-helper/src/main.rs
@@ -12,7 +12,7 @@
 //! mbrc-helper firewall --port <n>
 //! mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>
 //!                    [--relaunch-aumid <aumid>]
-//! mbrc-helper cleanup --pid <n> --target <dir>
+//! mbrc-helper cleanup --pid <n> --target <dir> --storage <dir>
 //! ```
 //!
 //! `cleanup` is the exception to "elevated": it runs as the user, and removes
@@ -76,7 +76,7 @@ USAGE:
     mbrc-helper firewall --port <n>
     mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>
                        [--relaunch-aumid <aumid>]
-    mbrc-helper cleanup --pid <n> --target <dir>
+    mbrc-helper cleanup --pid <n> --target <dir> --storage <dir>
     mbrc-helper --version
 
 COMMANDS:
@@ -160,7 +160,7 @@ fn run(args: &[String]) -> Result<u8, String> {
             }))
         }
         "cleanup" => {
-            let flags = parse_flags(&args[1..], &["pid", "target"])?;
+            let flags = parse_flags(&args[1..], &["pid", "target", "storage"])?;
             let pid = require(&flags, "pid")?;
             let pid: u32 = pid
                 .parse()
@@ -169,6 +169,7 @@ fn run(args: &[String]) -> Result<u8, String> {
             Ok(run_cleanup(&cleanup::Request {
                 pid,
                 target: require(&flags, "target")?,
+                storage: require(&flags, "storage")?,
             }))
         }
         other => Err(format!("unknown command {other:?}\n\n{USAGE}")),
@@ -238,8 +239,8 @@ fn run_cleanup(request: &cleanup::Request<'_>) -> u8 {
     log::direct_to_temp();
     log::note_environment();
     log::line(&format!(
-        "cleanup requested: pid={} target={}",
-        request.pid, request.target
+        "cleanup requested: pid={} target={} storage={}",
+        request.pid, request.target, request.storage
     ));
 
     let plan = match cleanup::plan(request) {

--- a/packages/mbrc-helper/src/main.rs
+++ b/packages/mbrc-helper/src/main.rs
@@ -12,7 +12,11 @@
 //! mbrc-helper firewall --port <n>
 //! mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>
 //!                    [--relaunch-aumid <aumid>]
+//! mbrc-helper cleanup --pid <n> --target <dir>
 //! ```
+//!
+//! `cleanup` is the exception to "elevated": it runs as the user, and removes
+//! the files a plugin uninstall inside MusicBee cannot remove itself.
 //!
 //! Exit codes are part of the contract with the caller, which reports them to
 //! the user. The old utility printed to a console nobody saw and always exited
@@ -24,6 +28,7 @@
 // which is the point: the create-or-update logic is platform-independent and CI
 // exercises it on both runners.
 #[cfg_attr(not(windows), allow(dead_code))]
+mod cleanup;
 mod firewall;
 mod log;
 mod update;
@@ -71,13 +76,18 @@ USAGE:
     mbrc-helper firewall --port <n>
     mbrc-helper update --pid <n> --staged <dir> --target <dir> --relaunch <exe>
                        [--relaunch-aumid <aumid>]
+    mbrc-helper cleanup --pid <n> --target <dir>
     mbrc-helper --version
 
 COMMANDS:
     firewall    Add or update the inbound firewall rule for the listening port.
     update      Re-verify and apply a staged update, then relaunch MusicBee.
+    cleanup     After MusicBee exits, remove the plugin files left behind by an
+                uninstall done inside MusicBee.
 
-Both commands require administrative rights.
+firewall and update require administrative rights; cleanup deliberately does
+not - it runs as the user, and a plugins directory that needs elevation belongs
+to an install whose own uninstaller removes these files.
 
 EXIT CODES:
     0  success                    5  the staged update did not verify
@@ -149,6 +159,18 @@ fn run(args: &[String]) -> Result<u8, String> {
                 relaunch_aumid: flags.get("relaunch-aumid").map(String::as_str),
             }))
         }
+        "cleanup" => {
+            let flags = parse_flags(&args[1..], &["pid", "target"])?;
+            let pid = require(&flags, "pid")?;
+            let pid: u32 = pid
+                .parse()
+                .map_err(|_| format!("--pid must be a process id, got {pid:?}"))?;
+
+            Ok(run_cleanup(&cleanup::Request {
+                pid,
+                target: require(&flags, "target")?,
+            }))
+        }
         other => Err(format!("unknown command {other:?}\n\n{USAGE}")),
     }
 }
@@ -201,6 +223,62 @@ fn run_update(request: &update::Request<'_>) -> u8 {
                 update::Error::RolledBack { .. } => EXIT_ROLLED_BACK,
                 update::Error::RollbackFailed { .. } => EXIT_ROLLBACK_FAILED,
             }
+        }
+    }
+}
+
+/// Removes what a plugin uninstall left behind, once MusicBee has exited.
+///
+/// Every outcome except a MusicBee that outlived the wait is a success: a
+/// directory with nothing left in it and a plugin that was added back again are
+/// both correct answers to "remove what is left", and neither is worth an error
+/// the caller cannot act on - by the time this runs, the caller is gone.
+fn run_cleanup(request: &cleanup::Request<'_>) -> u8 {
+    // No storage directory to log beside: the plugin deleted it on its way out.
+    log::direct_to_temp();
+    log::note_environment();
+    log::line(&format!(
+        "cleanup requested: pid={} target={}",
+        request.pid, request.target
+    ));
+
+    let plan = match cleanup::plan(request) {
+        Ok(plan) => plan,
+        Err(e) => {
+            log::line(&e.to_string());
+            return EXIT_USAGE;
+        }
+    };
+    if cleanup::running_from(&plan.target) {
+        // The caller is expected to run a copy from somewhere else, because a
+        // running image cannot be unlinked. Said here so the failure below reads
+        // as the consequence it is rather than a mystery.
+        log::line("running from the directory being cleaned; this build cannot remove itself");
+    }
+
+    match cleanup::run(&plan) {
+        cleanup::Outcome::Removed(files) => {
+            log::line(&format!("removed {}", files.join(", ")));
+            EXIT_OK
+        }
+        cleanup::Outcome::NothingToRemove => {
+            log::line("nothing left to remove");
+            EXIT_OK
+        }
+        cleanup::Outcome::StillInstalled => {
+            log::line("the plugin is installed again; left everything in place");
+            EXIT_OK
+        }
+        cleanup::Outcome::StillRunning => {
+            log::line("MusicBee did not exit in time; left everything in place");
+            EXIT_STILL_RUNNING
+        }
+        cleanup::Outcome::Partial { removed, failed } => {
+            if !removed.is_empty() {
+                log::line(&format!("removed {}", removed.join(", ")));
+            }
+            log::line(&format!("could not remove {}", failed.join("; ")));
+            EXIT_FAILED
         }
     }
 }

--- a/packages/mbrc-helper/src/update.rs
+++ b/packages/mbrc-helper/src/update.rs
@@ -141,7 +141,7 @@ impl fmt::Display for Error {
     }
 }
 
-type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 /// Checks and resolves the paths in a request.
 ///
@@ -441,7 +441,7 @@ pub fn clear_staged(plan: &Plan) {
 /// installed helper is one of the files being replaced. Falls back to false when
 /// the executable path cannot be resolved - then the delete is attempted and any
 /// failure is reported, which is the honest answer when we cannot tell.
-fn running_from(dir: &Path) -> bool {
+pub(crate) fn running_from(dir: &Path) -> bool {
     let Ok(exe) = std::env::current_exe() else {
         return false;
     };
@@ -473,7 +473,7 @@ fn backup_root(staged: &Path) -> Result<PathBuf> {
 
 /// Resolves a directory argument, refusing everything an elevated process should
 /// not follow.
-fn checked_dir(raw: &str, flag: &str) -> Result<PathBuf> {
+pub(crate) fn checked_dir(raw: &str, flag: &str) -> Result<PathBuf> {
     let path = checked_path(raw, flag)?;
     if !path.is_dir() {
         return Err(Error::Rejected(format!(
@@ -539,7 +539,7 @@ fn failed(path: &Path, e: std::io::Error) -> Error {
 /// exited before we looked or is not ours to wait on, and both mean waiting will
 /// never tell us anything.
 #[cfg(windows)]
-fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
+pub(crate) fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
     use windows::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
     use windows::Win32::System::Threading::{
         OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
@@ -559,7 +559,7 @@ fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
 }
 
 #[cfg(not(windows))]
-fn wait_for_exit(_pid: u32, _timeout: Duration) -> bool {
+pub(crate) fn wait_for_exit(_pid: u32, _timeout: Duration) -> bool {
     // Nothing to wait for off Windows; the apply path is exercised by tests that
     // inject their own wait.
     true

--- a/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
@@ -157,6 +157,28 @@ namespace MusicBeePlugin.Ffi.Generated
         internal static extern int mbrc_apply_staged_update();
 
         /// <summary>
+        ///  Remove the plugin files a MusicBee-side uninstall leaves behind.
+        ///
+        ///  MusicBee deletes `mb_remote.dll` when the user removes the plugin from
+        ///  Preferences and knows nothing about `mbrc_core.dll` and `mbrc-helper.exe`
+        ///  beside it. This core cannot delete itself while it is loaded, so it starts a
+        ///  copy of the helper that waits for MusicBee to exit and removes them then -
+        ///  and only if the plugin is still gone at that point, so adding it back in the
+        ///  same session is safe.
+        ///
+        ///  Takes nothing, for the same reason as `mbrc_apply_staged_update`: the
+        ///  directory is where this DLL was loaded from and the pid is our own, so there
+        ///  is nothing for a caller to name and nothing to tamper with.
+        ///
+        ///  Returns 1 if a cleanup was started, 0 otherwise - including the ordinary case
+        ///  of a plugins directory that needs elevation, where the installer's uninstaller
+        ///  is the route that removes these files. Never fails: a plugin being removed is
+        ///  not a moment to raise an error the user cannot act on.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "mbrc_request_plugin_cleanup", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern int mbrc_request_plugin_cleanup();
+
+        /// <summary>
         ///  Free a string previously returned to C# by the core. Null-safe. This is the
         ///  only Rust-owned allocation the C# side frees through us.
         ///

--- a/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
@@ -166,9 +166,15 @@ namespace MusicBeePlugin.Ffi.Generated
         ///  and only if the plugin is still gone at that point, so adding it back in the
         ///  same session is safe.
         ///
-        ///  Takes nothing, for the same reason as `mbrc_apply_staged_update`: the
-        ///  directory is where this DLL was loaded from and the pid is our own, so there
-        ///  is nothing for a caller to name and nothing to tamper with.
+        ///  The directory to remove files from is where this DLL was loaded from and the
+        ///  pid is our own, so neither is a parameter - there is nothing for a caller to
+        ///  name and nothing to tamper with. `storage_path` is: it is only read for
+        ///  whether it exists, which is how the helper tells "removed" from "removed and
+        ///  added straight back", and the worst a wrong value can do is call the removal
+        ///  off.
+        ///
+        ///  # Safety
+        ///  `storage_path` must be null or a valid NUL-terminated C string.
         ///
         ///  Returns 1 if a cleanup was started, 0 otherwise - including the ordinary case
         ///  of a plugins directory that needs elevation, where the installer's uninstaller
@@ -176,7 +182,7 @@ namespace MusicBeePlugin.Ffi.Generated
         ///  not a moment to raise an error the user cannot act on.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "mbrc_request_plugin_cleanup", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern int mbrc_request_plugin_cleanup();
+        internal static extern int mbrc_request_plugin_cleanup(byte* storage_path);
 
         /// <summary>
         ///  Free a string previously returned to C# by the core. Null-safe. This is the

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -665,6 +665,47 @@ namespace MusicBeePlugin.Ffi
 
         #endregion
 
+        /// <summary>
+        ///     Ask the core to remove what a plugin removal inside MusicBee leaves
+        ///     behind. MusicBee deletes mb_remote.dll and knows nothing about
+        ///     mbrc_core.dll or mbrc-helper.exe beside it; the core cannot delete
+        ///     itself while it is loaded, so it starts a copy of the helper that
+        ///     waits for MusicBee to exit and removes them then.
+        ///     Static and independent of <see cref="Initialize" />: MusicBee can call
+        ///     Uninstall after the host has been disposed, and the core needs no
+        ///     state to answer this - only to be loaded.
+        /// </summary>
+        /// <returns>true if a cleanup was started.</returns>
+        public static bool RequestPluginCleanup()
+        {
+            try
+            {
+                EnsureNativeLibraryLoaded();
+                return NativeMethods.mbrc_request_plugin_cleanup() != 0;
+            }
+            catch
+            {
+                // Nowhere to report to: this runs while the plugin is being torn
+                // down, and the logger writes through the very core we may have
+                // just failed to load.
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Loads mbrc_core.dll from the plugin's own directory unless it is
+        ///     already loaded, in which case LoadLibrary only bumps a refcount.
+        ///     The static counterpart to <see cref="PreloadNativeLibrary" />, for
+        ///     the calls that can arrive without a live bridge.
+        /// </summary>
+        private static void EnsureNativeLibraryLoaded()
+        {
+            var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (dir == null) return;
+            var dllPath = Path.Combine(dir, "mbrc_core.dll");
+            if (File.Exists(dllPath)) LoadLibrary(dllPath);
+        }
+
         /// <summary>Pre-load mbrc_core.dll from the plugin's own directory. Never throws.</summary>
         private void PreloadNativeLibrary()
         {

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -675,13 +675,24 @@ namespace MusicBeePlugin.Ffi
         ///     Uninstall after the host has been disposed, and the core needs no
         ///     state to answer this - only to be loaded.
         /// </summary>
+        /// <param name="storagePath">
+        ///     The storage directory the uninstall just deleted. The helper only
+        ///     reads whether it exists: MusicBee defers deleting mb_remote.dll to
+        ///     its next start, so the plugin file is no signal, while a storage
+        ///     directory that is back means the plugin loaded again and nothing is
+        ///     to be removed.
+        /// </param>
         /// <returns>true if a cleanup was started.</returns>
-        public static bool RequestPluginCleanup()
+        public static unsafe bool RequestPluginCleanup(string storagePath)
         {
             try
             {
                 EnsureNativeLibraryLoaded();
-                return NativeMethods.mbrc_request_plugin_cleanup() != 0;
+                var pathBytes = Encoding.UTF8.GetBytes((storagePath ?? string.Empty) + "\0");
+                fixed (byte* pathPtr = pathBytes)
+                {
+                    return NativeMethods.mbrc_request_plugin_cleanup(pathPtr) != 0;
+                }
             }
             catch
             {

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
+using MusicBeePlugin.Ffi;
 using MusicBeePlugin.Host;
 using MusicBeePlugin.Settings;
 using FfiGen = MusicBeePlugin.Ffi.Generated;
@@ -309,7 +310,14 @@ namespace MusicBeePlugin
         }
 
         /// <summary>
-        ///     Cleans up any persisted files during the plugin uninstall.
+        ///     Cleans up after the plugin when it is removed from MusicBee's
+        ///     Preferences: the stored settings, caches and logs, and then the two
+        ///     files MusicBee itself will not remove.
+        ///     MusicBee deletes mb_remote.dll, the assembly it loaded, and has never
+        ///     heard of mbrc_core.dll or mbrc-helper.exe beside it. The core cannot
+        ///     delete itself either - it is mapped into this process - so it starts a
+        ///     copy of the helper that waits for MusicBee to exit and removes them
+        ///     then, and only if the plugin is still gone at that point.
         /// </summary>
         public void Uninstall()
         {
@@ -325,6 +333,10 @@ namespace MusicBeePlugin
             {
                 // Best-effort cleanup; never throw out of Uninstall.
             }
+
+            // Deliberately after the storage delete: the helper only removes files,
+            // and losing it costs two stray files rather than a settings folder.
+            NativeBridge.RequestPluginCleanup();
         }
 
         /// <summary>

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -321,11 +321,11 @@ namespace MusicBeePlugin
         /// </summary>
         public void Uninstall()
         {
+            var settingsFolder = Path.Combine(
+                _api.Setting_GetPersistentStoragePath(),
+                "mb_remote");
             try
             {
-                var settingsFolder = Path.Combine(
-                    _api.Setting_GetPersistentStoragePath(),
-                    "mb_remote");
                 if (Directory.Exists(settingsFolder))
                     Directory.Delete(settingsFolder, true);
             }
@@ -334,9 +334,10 @@ namespace MusicBeePlugin
                 // Best-effort cleanup; never throw out of Uninstall.
             }
 
-            // Deliberately after the storage delete: the helper only removes files,
-            // and losing it costs two stray files rather than a settings folder.
-            NativeBridge.RequestPluginCleanup();
+            // Deliberately after the storage delete: the helper reads that folder's
+            // absence as "the plugin really is gone", and losing this call costs a
+            // few stray files rather than a settings folder.
+            NativeBridge.RequestPluginCleanup(settingsFolder);
         }
 
         /// <summary>


### PR DESCRIPTION
Stacked on #190 (the installer's uninstaller). This one is the other half: removing the plugin
from **inside MusicBee**.

MusicBee deletes `mb_remote.dll` - the assembly it loaded - and nothing else. `mbrc_core.dll` and
`mbrc-helper.exe` sit beside it as ordinary files it has never heard of, so both survive. The
core cannot delete itself either: it is mapped into MusicBee for as long as MusicBee runs.

## How it works

`Plugin.Uninstall()` deletes the storage directory as before, then calls a new
`mbrc_request_plugin_cleanup()`. The core copies `mbrc-helper.exe` to `%TEMP%` and starts the
copy with `cleanup --pid <musicbee> --target <plugins dir>`. The copy:

1. waits for MusicBee to exit (one hour - nothing is pending and nobody is watching),
2. re-checks that `mb_remote.dll` is still gone, so adding the plugin back in the same session
   does not get the core deleted out from under it,
3. removes `mbrc_core.dll`, the retired `firewall-utility.exe` if present, and itself.

**It never elevates.** A plugins directory that needs administrator rights belongs to an install
that came from the installer, and its uninstaller removes these files; a UAC prompt in the middle
of a plugin removal is a surprise nobody asked for. That case is a quiet no in the log. There is
no privilege boundary here, so unlike the update path there is nothing to verify before running.

`cleanup` logs to `%TEMP%\mbrc-helper.log`, because the storage directory it would normally log
beside was deleted moments earlier by the same uninstall.

## Verification

Rust: 7 new unit tests (63 total in the helper), clippy clean.

Live, driving the built helper directly:

- plugins directory with `mbrc_core.dll` + `firewall-utility.exe` + `mbrc-helper.exe`, run from a
  temp copy: `removed mbrc_core.dll, firewall-utility.exe, mbrc-helper.exe`, exit 0, directory
  empty.
- same with `mb_remote.dll` present: `the plugin is installed again; left everything in place`,
  exit 0, nothing touched.
- run from *inside* the target: logs that it cannot remove itself, removes the core, exits 1 with
  `could not remove mbrc-helper.exe: Access is denied`. That is the case the temp copy exists to
  avoid, and it fails loudly rather than silently.

Not yet run: the full path through MusicBee (remove plugin in Preferences, quit, check the
folder). That needs a live install and is the last check before merge.
