### PR TITLE
fix(uninstall): clean up the core, the helper and the menu entry

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -73,8 +73,8 @@ runs:
           "build\dist\mb_remote.dll",
           "build\dist\mbrc_core.dll",
           "build\dist\mbrc-helper.exe",
-          "build\dist\LICENSE",
-          "build\dist\README.txt"
+          "build\dist\MBRC_LICENSE.txt",
+          "build\dist\MBRC_README.txt"
         )
         Compress-Archive -Path $files -DestinationPath "build\dist\$env:BASE.zip"
 
@@ -121,9 +121,9 @@ runs:
           }
         }
 
-        # Exactly the files the updater installs. LICENSE and README.txt ride
-        # along in the zip but are not applied, so they are not listed: the
-        # extractor writes only what appears here.
+        # Exactly the files the updater installs. MBRC_LICENSE.txt and
+        # MBRC_README.txt ride along in the zip but are not applied, so they are
+        # not listed: the extractor writes only what appears here.
         $bundled = @('mb_remote.dll', 'mbrc_core.dll', 'mbrc-helper.exe')
         $files = foreach ($name in $bundled) {
           [ordered]@{

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,8 +184,13 @@ jobs:
           cp target/i686-pc-windows-msvc/plugin/mbrc_core.dll build/dist
           # Elevated helper, built alongside the core by build.ps1 -Rust.
           cp target/i686-pc-windows-msvc/plugin/mbrc-helper.exe build/dist
-          cp LICENSE build/dist
-          cp installer/README.txt build/dist
+          # Prefixed, and not because it is tidier: the zip is extracted straight
+          # into MusicBee's Plugins folder, where a `README.txt` lands on top of
+          # MusicBee's own `readme.txt` - same file, Windows being
+          # case-insensitive. These names collide with nothing and are obviously
+          # ours, so an uninstall can remove them.
+          cp LICENSE build/dist/MBRC_LICENSE.txt
+          cp installer/README.txt build/dist/MBRC_README.txt
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ shipped Android and iOS client keeps working untouched.
   already recovered.
 - A MusicBee too old for the plugin now says so, in the plugin list and in a log
   file, instead of loading and silently doing nothing.
+- The installer's uninstaller removed nothing. It looked for the plugin files one
+  directory deeper than they are, so every delete missed, and it still reported
+  that the plugin had been removed. Removing the plugin inside MusicBee instead
+  leaves `mbrc_core.dll` and `mbrc-helper.exe` behind, since MusicBee only knows
+  about the file it loaded - delete those two by hand, or use the uninstaller
+  (#192).
 - Single-file albums split by a `.cue` sheet showed in the now-playing list as a
   row of "Unknown Artist" per track. Every such track reports the same container
   file, so reading tags by file returned nothing for all of them; the list now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,18 @@ shipped Android and iOS client keeps working untouched.
   file, instead of loading and silently doing nothing.
 - The installer's uninstaller removed nothing. It looked for the plugin files one
   directory deeper than they are, so every delete missed, and it still reported
-  that the plugin had been removed. Removing the plugin inside MusicBee instead
-  leaves `mbrc_core.dll` and `mbrc-helper.exe` behind, since MusicBee only knows
-  about the file it loaded - delete those two by hand, or use the uninstaller
-  (#192).
+  that the plugin had been removed.
+- Removing the plugin inside MusicBee used to leave `mbrc_core.dll` and
+  `mbrc-helper.exe` in the Plugins folder, because MusicBee only knows about the
+  assembly it loaded. The plugin now unloads the native core and deletes it, the
+  helper and its own text files itself, takes its entry out of the Tools menu,
+  and clears its stored data - all without closing MusicBee (#192).
+- Removing the plugin while the cover cache was building froze MusicBee until the
+  build finished. Teardown now tells the build to stop first and it gives up
+  between albums, keeping what it had already built for next time.
+- The archive's `LICENSE` and `README.txt` overwrote MusicBee's own `readme.txt`
+  in the Plugins folder, and earlier versions left both behind on every update.
+  They ship as `MBRC_LICENSE.txt` and `MBRC_README.txt` now.
 - Single-file albums split by a `.cue` sheet showed in the now-playing list as a
   row of "Unknown Artist" per track. Every such track reports the same container
   file, so reading tags by file returned nothing for all of them; the list now

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ Use this method for the Microsoft Store version of MusicBee or if you prefer man
 
 After installation, the plugin should appear in MusicBee under `Edit > Preferences > Plugins`.
 
+### Uninstalling
+
+If you installed with the installer, use `Uninstall MusicBee Remote` from the Start
+Menu (or `mbremoteuninstall.exe` in MusicBee's `Plugins` folder). It removes all
+three files and the plugin's stored settings, caches and logs.
+
+If you installed from the zip, remove the plugin in MusicBee under
+`Edit > Preferences > Plugins`. That deletes the plugin's stored data straight away,
+and MusicBee deletes `mb_remote.dll` itself the next time it starts. `mbrc_core.dll`
+and `mbrc-helper.exe` are left behind - MusicBee only knows about the assembly it
+loaded - so delete those two from the `Plugins` folder yourself ([#192][issue-192]).
+
+[issue-192]: https://github.com/musicbeeremote/mbrc-plugin/issues/192
+
 ## Getting Started
 
 As a developer there are a few steps you need to follow to get started:

--- a/README.md
+++ b/README.md
@@ -155,12 +155,10 @@ Menu (or `mbremoteuninstall.exe` in MusicBee's `Plugins` folder). It removes all
 three files and the plugin's stored settings, caches and logs.
 
 If you installed from the zip, remove the plugin in MusicBee under
-`Edit > Preferences > Plugins`. That deletes the plugin's stored data straight away,
-and MusicBee deletes `mb_remote.dll` itself the next time it starts. `mbrc_core.dll`
-and `mbrc-helper.exe` are left behind - MusicBee only knows about the assembly it
-loaded - so delete those two from the `Plugins` folder yourself ([#192][issue-192]).
-
-[issue-192]: https://github.com/musicbeeremote/mbrc-plugin/issues/192
+`Edit > Preferences > Plugins`. It takes its own files with it: `mbrc_core.dll`,
+`mbrc-helper.exe` and the two text files, plus the stored settings, caches and
+logs, all while MusicBee is still running. MusicBee deletes `mb_remote.dll` itself
+the next time it starts, so the folder is only fully clear after a restart.
 
 ## Getting Started
 

--- a/installer/MusicBeeRemote.nsi
+++ b/installer/MusicBeeRemote.nsi
@@ -118,14 +118,18 @@ Function un.onInit
 FunctionEnd
 
 Section Uninstall
-	; Plugin files live under $INSTDIR\Plugins (see SetOutPath above).
-	Delete "$INSTDIR\Plugins\mb_remote.dll"
-	Delete "$INSTDIR\Plugins\mbrc_core.dll"
-	Delete "$INSTDIR\Plugins\mbrc-helper.exe"
+	; $INSTDIR is NOT what it was during install. The uninstaller was written to
+	; $INSTDIR\Plugins, and an uninstaller initialises $INSTDIR to the directory it
+	; lives in, so here $INSTDIR is the plugins directory itself. Prefixing these
+	; with Plugins\ again pointed every delete at a directory that does not exist,
+	; and the uninstall removed nothing while still reporting success.
+	Delete "$INSTDIR\mb_remote.dll"
+	Delete "$INSTDIR\mbrc_core.dll"
+	Delete "$INSTDIR\mbrc-helper.exe"
 	; Also clear the pre-1.5.0 C# utility, in case this uninstall follows an
 	; upgrade from an install that had it.
-	Delete "$INSTDIR\Plugins\firewall-utility.exe"
-	Delete "$INSTDIR\Plugins\mbremoteuninstall.exe"
+	Delete "$INSTDIR\firewall-utility.exe"
+	Delete "$INSTDIR\mbremoteuninstall.exe"
 	RmDir /r "$APPDATA\MusicBee\mb_remote"
 
 	; Remove Start Menu items

--- a/installer/MusicBeeRemote.nsi
+++ b/installer/MusicBeeRemote.nsi
@@ -129,6 +129,10 @@ Section Uninstall
 	; Also clear the pre-1.5.0 C# utility, in case this uninstall follows an
 	; upgrade from an install that had it.
 	Delete "$INSTDIR\firewall-utility.exe"
+	; A zip install into the same folder leaves these; the installer never
+	; writes them, and nothing else is named this way.
+	Delete "$INSTDIR\MBRC_LICENSE.txt"
+	Delete "$INSTDIR\MBRC_README.txt"
 	Delete "$INSTDIR\mbremoteuninstall.exe"
 	RmDir /r "$APPDATA\MusicBee\mb_remote"
 

--- a/installer/README.txt
+++ b/installer/README.txt
@@ -23,17 +23,24 @@ to install directly from the zip file.
 UNINSTALLATION
 --------------
 
-Close MusicBee, then delete all three files from the Plugins folder:
+Go to MusicBee -> Edit -> Preferences -> Plugins and use "Remove" on MusicBee
+Remote. The plugin removes its own files - mbrc_core.dll, mbrc-helper.exe and
+these two text files - along with everything it stored: the settings, the log,
+the library and cover caches, and any downloaded update.
+
+MusicBee deletes mb_remote.dll itself the next time it starts, so the Plugins
+folder is only fully clear after a restart. Nothing else is left behind.
+
+If you would rather do it by hand, close MusicBee and delete these from the
+Plugins folder:
 
     mb_remote.dll
     mbrc_core.dll
     mbrc-helper.exe
+    MBRC_LICENSE.txt
+    MBRC_README.txt
 
-Deleting only mb_remote.dll leaves the native core behind.
-
-The plugin stores its data under %APPDATA%\MusicBee\mb_remote\
-This folder can be safely deleted after uninstallation. It holds the settings,
-the log, the library and cover caches, and any downloaded update.
+then delete the data folder at %APPDATA%\MusicBee\mb_remote\
 
 
 REQUIREMENTS

--- a/packages/mbrc-core/src/cover/store.rs
+++ b/packages/mbrc-core/src/cover/store.rs
@@ -63,6 +63,9 @@ pub struct BuildStats {
     pub slowest_ms: u128,
     /// The slowest single cover's track path.
     pub slowest_path: String,
+    /// The build stopped early because it was asked to - the core is shutting
+    /// down. Not a failure: what was built is kept and the next build resumes.
+    pub stopped: bool,
 }
 
 pub struct CoverStore {
@@ -208,15 +211,29 @@ impl CoverStore {
     where
         F: Fn(&str) -> Option<Vec<u8>>,
     {
+        self.build_until(fetch_raw, verbose, &|| false)
+    }
+
+    /// As [`Self::build`], but stops early when `stop` says so.
+    ///
+    /// Checked between albums, which is the only place it can be: a fetch is one
+    /// blocking call into MusicBee and a store is one image. What has been built
+    /// is still pruned and persisted, and the next build picks up the rest -
+    /// "missing" is recomputed from what is actually on disk every time, so a
+    /// half-finished build is a resumable one rather than a broken cache.
+    pub fn build_until<F>(&self, fetch_raw: F, verbose: bool, stop: &dyn Fn() -> bool) -> BuildStats
+    where
+        F: Fn(&str) -> Option<Vec<u8>>,
+    {
         if self.building.swap(true, Ordering::AcqRel) {
             return BuildStats::default(); // a build is already running
         }
-        let stats = self.build_inner(fetch_raw, verbose);
+        let stats = self.build_inner(fetch_raw, verbose, stop);
         self.building.store(false, Ordering::Release);
         stats
     }
 
-    fn build_inner<F>(&self, fetch_raw: F, verbose: bool) -> BuildStats
+    fn build_inner<F>(&self, fetch_raw: F, verbose: bool, stop: &dyn Fn() -> bool) -> BuildStats
     where
         F: Fn(&str) -> Option<Vec<u8>>,
     {
@@ -315,6 +332,10 @@ impl CoverStore {
             // thread) and feed the queue. `send` blocks when the bound is hit,
             // giving back-pressure so memory stays bounded.
             for (key, path) in missing {
+                if stop() {
+                    stats.stopped = true;
+                    break;
+                }
                 let fetch_start = Instant::now();
                 let raw = fetch_raw(&path);
                 let fetch_ms = fetch_start.elapsed().as_millis();
@@ -449,6 +470,8 @@ fn now_unix_secs() -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+
     use super::*;
     use crate::cover::test_jpeg_bytes as jpeg_bytes;
 
@@ -575,6 +598,52 @@ mod tests {
             modified: last_check + 1000,
         }]);
         assert_eq!(store2.hash_for("alb1"), None);
+    }
+
+    #[test]
+    fn build_stops_when_asked_and_keeps_what_it_built() {
+        // Teardown waits for this build, so it has to be able to give up between
+        // albums - and what it managed has to survive, because the next build
+        // recomputes what is missing rather than starting over.
+        let (db, dir) = temp_storage("build-stops");
+        let store = CoverStore::new(db.clone(), &dir);
+        store.warm_up(&[
+            AlbumIdentity {
+                key: "alb1".into(),
+                path: "/a.mp3".into(),
+                modified: 0,
+            },
+            AlbumIdentity {
+                key: "alb2".into(),
+                path: "/b.mp3".into(),
+                modified: 0,
+            },
+            AlbumIdentity {
+                key: "alb3".into(),
+                path: "/c.mp3".into(),
+                modified: 0,
+            },
+        ]);
+
+        let art = jpeg_bytes(300, 300);
+        let fetched = AtomicUsize::new(0);
+        let stats = store.build_until(
+            |_| {
+                fetched.fetch_add(1, Ordering::AcqRel);
+                Some(art.clone())
+            },
+            false,
+            // Stop once the first album has been fetched.
+            &|| fetched.load(Ordering::Acquire) >= 1,
+        );
+
+        assert!(
+            stats.stopped,
+            "the build should report that it gave up early"
+        );
+        assert_eq!(fetched.load(Ordering::Acquire), 1);
+        assert_eq!(stats.stored, 1);
+        assert_eq!(store.cached_count(), 1, "the one it built is kept");
     }
 
     #[test]

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -134,6 +134,21 @@ pub extern "C" fn mbrc_stop_networking() -> c_int {
     ffi_guard("mbrc_stop_networking", || state::stop_networking() as c_int)
 }
 
+/// Tell the long-running background work to wind down. Stops nothing by itself.
+///
+/// Notice, not an order to shut down: the cover build is minutes of blocking
+/// work on a first run, and teardown waits for it. A host that knows it is about
+/// to tear down - an uninstall, say, which first closes a window and removes a
+/// menu entry - can call this and hand those milliseconds to the build as a head
+/// start, so the wait in `mbrc_stop_networking` is usually already over.
+///
+/// Cleared by the next `mbrc_start_networking`, so a stop/start (a port change)
+/// is unaffected. Idempotent.
+#[no_mangle]
+pub extern "C" fn mbrc_begin_stopping() -> c_int {
+    ffi_guard("mbrc_begin_stopping", || state::begin_stopping() as c_int)
+}
+
 /// Read the core's current settings as a MessagePack buffer for the settings
 /// panel. Writes the byte length to `out_len` and returns a Rust-owned pointer
 /// that C# must release via [`mbrc_free_bytes`]. Returns null (and leaves

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -365,6 +365,14 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
                 );
             }
 
+            // Between the two halves: the metadata pass is done and persisted,
+            // and the cover build is the expensive half nobody is waiting for
+            // once MusicBee is on its way out.
+            if core.is_stopping() {
+                tracing::info!("core is stopping; skipping the cover cache build");
+                return;
+            }
+
             if scope.does_covers() {
                 core.cover_store.warm_up(&identities);
                 let prep_ms = started.elapsed().as_millis();
@@ -376,7 +384,7 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
 
                 let build_started = std::time::Instant::now();
                 let providers = core.providers.clone();
-                let stats = core.cover_store.build(
+                let stats = core.cover_store.build_until(
                     |path| {
                         let b64 = providers.artwork_raw(path).ok()?;
                         if b64.is_empty() {
@@ -385,6 +393,10 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
                         from_base64(&b64)
                     },
                     core.config.log_level.is_trace(),
+                    // A first build of a large library is minutes of blocking
+                    // work, and teardown waits for it. Stopping between albums
+                    // is what keeps MusicBee's exit from waiting on covers.
+                    &|| core.is_stopping(),
                 );
                 tracing::info!(
                     albums = album_count,
@@ -397,6 +409,7 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
                     store_ms = stats.store_ms,
                     slowest_ms = stats.slowest_ms,
                     slowest_path = %stats.slowest_path,
+                    stopped = stats.stopped,
                     build_ms = build_started.elapsed().as_millis(),
                     total_ms = started.elapsed().as_millis(),
                     "cover cache build complete"
@@ -466,7 +479,7 @@ pub(crate) fn refresh_covers_delta(core: &Arc<Core>) {
     let dropped = before.saturating_sub(kept);
 
     let providers = core.providers.clone();
-    let stats = core.cover_store.build(
+    let stats = core.cover_store.build_until(
         |path| {
             let b64 = providers.artwork_raw(path).ok()?;
             if b64.is_empty() {
@@ -475,6 +488,7 @@ pub(crate) fn refresh_covers_delta(core: &Arc<Core>) {
             from_base64(&b64)
         },
         core.config.log_level.is_trace(),
+        &|| core.is_stopping(),
     );
 
     let changed = dropped > 0 || stats.stored > 0;

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -514,6 +514,23 @@ pub fn handle_notification(ntype: NotificationType) -> MbrcResult {
     MbrcResult::Ok
 }
 
+/// Tell the background work to wind down, without stopping anything yet.
+///
+/// For a host that knows it is about to tear down but has its own work to do
+/// first - an uninstall closes a window and takes a menu entry out before it
+/// disposes anything. Those are milliseconds, and this hands them to the cover
+/// build as notice, so by the time the join comes it has usually already
+/// stopped. Idempotent, and safe to call when nothing is running.
+pub fn begin_stopping() -> MbrcResult {
+    match lock().as_ref() {
+        Some(runtime) => {
+            runtime.core.begin_stopping();
+            MbrcResult::Ok
+        }
+        None => MbrcResult::NotInitialized,
+    }
+}
+
 /// Stop networking (if running) and drop the core, allowing a later re-init.
 pub fn shutdown() -> MbrcResult {
     let mut guard = lock();
@@ -690,6 +707,23 @@ mod tests {
         assert_eq!(merged.port, 7000);
         assert_eq!(merged.allowed_addresses, vec!["10.0.0.2"]); // lists replace
         assert_eq!(merged.tcp_keepalive_secs, 99); // absent key untouched
+    }
+
+    #[test]
+    fn stopping_is_set_for_teardown_and_cleared_for_a_restart() {
+        let core = Core::new(Arc::new(NullProviders), Config::default());
+        assert!(!core.is_stopping());
+
+        core.begin_stopping();
+        assert!(core.is_stopping());
+        core.begin_stopping(); // idempotent: the host may say so more than once
+        assert!(core.is_stopping());
+
+        // Saving a new port stops and restarts networking on the same core. If
+        // the flag survived that, the cover build would never run again for the
+        // rest of the session and nothing would say why.
+        core.clear_stopping();
+        assert!(!core.is_stopping());
     }
 
     #[test]

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -93,9 +93,22 @@ impl Core {
     }
 
     /// Tell the long-running background work to stop at its next checkpoint.
-    /// One-way: a core that is stopping is on its way out.
+    ///
+    /// Set by both teardown paths, because the host uses both: `PluginHost` calls
+    /// `mbrc_stop_networking` and only then `mbrc_shutdown`, so setting this in
+    /// the latter alone means it is set after the wait it exists to prevent.
     pub fn begin_stopping(&self) {
         self.stopping.store(true, Ordering::Release);
+    }
+
+    /// Clear it again, because stopping networking is not always leaving.
+    ///
+    /// Saving a new port stops and restarts networking on the same core, and a
+    /// flag left set there would silently disable the cover build for the rest
+    /// of the session. Cleared as networking starts, which is also what kicks
+    /// the reconcile that reads it.
+    pub fn clear_stopping(&self) {
+        self.stopping.store(false, Ordering::Release);
     }
 
     /// Whether teardown has started. Checked between items by work that would
@@ -528,6 +541,9 @@ pub fn start_networking() -> MbrcResult {
     if runtime.net.is_some() {
         return MbrcResult::AlreadyRunning;
     }
+    // A previous stop (a port change, say) left this set; the work it gates is
+    // started by the call below.
+    runtime.core.clear_stopping();
     match server::start(runtime.core.clone()) {
         Ok(net) => {
             runtime.net = Some(net);
@@ -548,6 +564,9 @@ pub fn stop_networking() -> MbrcResult {
     };
     match runtime.net.take() {
         Some(net) => {
+            // Before the join inside `stop`: this is the call the host makes
+            // first, so it is the one that has to release the long blocking work.
+            runtime.core.begin_stopping();
             net.stop();
             MbrcResult::Ok
         }

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -51,6 +51,15 @@ pub struct Core {
     /// change notification (`FileAddedToLibrary`) is a debounced nudge on this,
     /// not a full cache clear (see `server::scanner`).
     pub scanner_nudge: Arc<Notify>,
+    /// Set when the core is being torn down, and read by the long blocking work
+    /// so it can stop between items.
+    ///
+    /// Without it, teardown waits for whatever is running: the cover build is a
+    /// `spawn_blocking` task, and dropping a Tokio runtime waits for blocking
+    /// tasks to finish. A first-run build of a large library is minutes of that,
+    /// and MusicBee's own exit is what waits - closing MusicBee shortly after a
+    /// fresh install would hang until every cover was cached.
+    stopping: Arc<AtomicBool>,
 }
 
 impl Core {
@@ -79,7 +88,20 @@ impl Core {
             blocked: BlockedLog::default(),
             conn_counter: AtomicU64::new(0),
             scanner_nudge: Arc::new(Notify::new()),
+            stopping: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Tell the long-running background work to stop at its next checkpoint.
+    /// One-way: a core that is stopping is on its way out.
+    pub fn begin_stopping(&self) {
+        self.stopping.store(true, Ordering::Release);
+    }
+
+    /// Whether teardown has started. Checked between items by work that would
+    /// otherwise hold MusicBee's shutdown - see [`Core::stopping`].
+    pub fn is_stopping(&self) -> bool {
+        self.stopping.load(Ordering::Acquire)
     }
 
     /// A fresh per-connection id (used as the broadcast-registry key).
@@ -484,6 +506,10 @@ pub fn shutdown() -> MbrcResult {
     let mut guard = lock();
     match guard.take() {
         Some(runtime) => {
+            // Before the join below: the blocking work checks this between
+            // items, and everything it is told to stop doing is time MusicBee
+            // would otherwise spend waiting to exit.
+            runtime.core.begin_stopping();
             if let Some(net) = runtime.net {
                 net.stop();
             }

--- a/packages/plugin/Ffi/FfiLogger.cs
+++ b/packages/plugin/Ffi/FfiLogger.cs
@@ -51,6 +51,14 @@ namespace MusicBeePlugin.Ffi
         /// <summary>Enable forwarding once the core has been initialized.</summary>
         public static void MarkReady() => _ready = true;
 
+        /// <summary>
+        ///     Stop forwarding, because the core is going away. Called before the
+        ///     native library is unloaded during an uninstall: a log line after that
+        ///     point would call into an unmapped image and take MusicBee with it.
+        ///     Lines fall back to the bootstrap file, exactly as they do before init.
+        /// </summary>
+        public static void MarkUnavailable() => _ready = false;
+
         public void Debug(string message) => Emit(LevelDebug, message);
         public void Debug(string messageTemplate, params object[] args) => Emit(LevelDebug, Format(messageTemplate, args));
         public void Info(string message) => Emit(LevelInfo, message);

--- a/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
@@ -51,6 +51,21 @@ namespace MusicBeePlugin.Ffi.Generated
         internal static extern int mbrc_stop_networking();
 
         /// <summary>
+        ///  Tell the long-running background work to wind down. Stops nothing by itself.
+        ///
+        ///  Notice, not an order to shut down: the cover build is minutes of blocking
+        ///  work on a first run, and teardown waits for it. A host that knows it is about
+        ///  to tear down - an uninstall, say, which first closes a window and removes a
+        ///  menu entry - can call this and hand those milliseconds to the build as a head
+        ///  start, so the wait in `mbrc_stop_networking` is usually already over.
+        ///
+        ///  Cleared by the next `mbrc_start_networking`, so a stop/start (a port change)
+        ///  is unaffected. Idempotent.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "mbrc_begin_stopping", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern int mbrc_begin_stopping();
+
+        /// <summary>
         ///  Read the core's current settings as a MessagePack buffer for the settings
         ///  panel. Writes the byte length to `out_len` and returns a Rust-owned pointer
         ///  that C# must release via [`mbrc_free_bytes`]. Returns null (and leaves

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -204,6 +204,27 @@ namespace MusicBeePlugin.Ffi
             }
         }
 
+        /// <summary>
+        ///     Tell the core's background work to wind down. Stops nothing by
+        ///     itself and returns immediately.
+        ///     Notice, given ahead of a teardown the caller knows is coming: the
+        ///     cover build is minutes of blocking work on a first run and
+        ///     <see cref="StopNetworking" /> waits for it, so anything the caller
+        ///     still has to do first is time the build can spend stopping.
+        /// </summary>
+        public void BeginStopping()
+        {
+            if (!_initialized) return;
+            try
+            {
+                _ = NativeMethods.mbrc_begin_stopping();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to signal the core to stop");
+            }
+        }
+
         public void StopNetworking()
         {
             if (!_initialized) return;

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -64,6 +64,18 @@ namespace MusicBeePlugin.Ffi
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool FreeLibrary(IntPtr hModule);
 
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        /// <summary>The native core, as the loader knows it.</summary>
+        private const string NativeLibraryFileName = "mbrc_core.dll";
+
+        /// <summary>
+        ///     Enough to unwind any plausible reference count, and a bound rather
+        ///     than a `while (true)` because this runs inside MusicBee.
+        /// </summary>
+        private const int MaxUnloadAttempts = 64;
+
         #endregion
 
         private readonly QueryHandlers _queries;
@@ -664,6 +676,41 @@ namespace MusicBeePlugin.Ffi
         }
 
         #endregion
+
+        /// <summary>
+        ///     Unmap mbrc_core.dll from this process so the file can be deleted.
+        ///     Windows will not unlink a loaded image, and the plugin cannot outlive
+        ///     MusicBee to do it later, so an uninstall that wants to remove the core
+        ///     has to unload it first.
+        ///     Freed in a loop rather than once: this class holds one reference from
+        ///     its own preload, and the CLR holds another from resolving the DllImports
+        ///     - which it never releases, since a P/Invoke module stays for the life of
+        ///     the process. Dropping ours alone leaves the file mapped.
+        ///     After this returns 0 modules loaded, **every** NativeMethods call is an
+        ///     access violation waiting to happen: the IL stubs hold cached addresses
+        ///     into an image that is no longer there. Only call it from
+        ///     <see cref="Plugin.Uninstall" />, after the host is disposed and
+        ///     <see cref="FfiLogger.MarkUnavailable" /> has stopped log forwarding.
+        /// </summary>
+        /// <returns>true if the module is no longer loaded.</returns>
+        public static bool UnloadNativeLibrary()
+        {
+            try
+            {
+                for (var attempt = 0; attempt < MaxUnloadAttempts; attempt++)
+                {
+                    var module = GetModuleHandle(NativeLibraryFileName);
+                    if (module == IntPtr.Zero) return true;
+                    if (!FreeLibrary(module)) return false;
+                }
+
+                return GetModuleHandle(NativeLibraryFileName) == IntPtr.Zero;
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
         /// <summary>Pre-load mbrc_core.dll from the plugin's own directory. Never throws.</summary>
         private void PreloadNativeLibrary()

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -222,6 +222,18 @@ namespace MusicBeePlugin.Host
             return true;
         }
 
+        /// <summary>
+        ///     Tell the core to wind its background work down, without stopping
+        ///     anything yet. For a caller that knows it is about to
+        ///     <see cref="Dispose" /> but has its own work to do first - the cover
+        ///     build gets that time as notice, and <see cref="Dispose" /> is what
+        ///     would otherwise wait for it.
+        /// </summary>
+        public void BeginStopping()
+        {
+            _bridge.BeginStopping();
+        }
+
         public void Dispose()
         {
             if (_disposed) return;

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -32,6 +32,14 @@ namespace MusicBeePlugin
         /// <summary>The preferences panel, built lazily in <see cref="Configure" />.</summary>
         private ConfigurationPanel _configPanel;
 
+        /// <summary>
+        ///     The Tools menu entry, kept so an uninstall can take it back out.
+        ///     MusicBee hands the item back when it is added and never removes it
+        ///     itself, so without this the entry stays in the menu - pointing at a
+        ///     plugin that is gone - until MusicBee is restarted.
+        /// </summary>
+        private ToolStripItem _menuItem;
+
         /// <summary>Plugin version string, shown in the preferences panel.</summary>
         private string _version;
 
@@ -134,7 +142,7 @@ namespace MusicBeePlugin
 
                 // A Tools menu entry opens the same settings dialog as the Configure
                 // button, matching the classic plugin's layout.
-                _api.MB_AddMenuItem(
+                _menuItem = _api.MB_AddMenuItem(
                     "mnuTools/MusicBee Remote",
                     "MusicBee Remote: open settings",
                     (sender, args) => OpenSettingsDialog());
@@ -323,6 +331,11 @@ namespace MusicBeePlugin
         /// </remarks>
         public void Uninstall()
         {
+            // First, and on the UI thread this is called on: the entry is the one
+            // visible trace of the plugin, and leaving it until after the teardown
+            // means it points at nothing for as long as that takes.
+            RemoveMenuItem();
+
             try
             {
                 SettingsWindow.CloseIfOpen();
@@ -368,6 +381,48 @@ namespace MusicBeePlugin
         {
             "mbrc-helper.exe", "MBRC_LICENSE.txt", "MBRC_README.txt",
         };
+
+        /// <summary>
+        ///     Takes the Tools entry back out of the menu it was added to.
+        ///     MusicBee returns the item when it is added and offers no way to remove
+        ///     one, so this goes through the item's own owner. Never throws: an
+        ///     uninstall that fails here has still uninstalled everything else.
+        /// </summary>
+        private void RemoveMenuItem()
+        {
+            var item = _menuItem;
+            _menuItem = null;
+            if (item == null) return;
+
+            try
+            {
+                var owner = item.Owner ?? item.GetCurrentParent();
+                if (owner == null)
+                {
+                    item.Dispose();
+                    return;
+                }
+
+                // Called from the Preferences dialog, so this is already the UI
+                // thread - but the menu belongs to MusicBee's main form, and
+                // touching another thread's controls is how a plugin takes the host
+                // down with it.
+                if (owner.InvokeRequired)
+                    owner.Invoke(new Action(() => DetachMenuItem(owner, item)));
+                else
+                    DetachMenuItem(owner, item);
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Plugin Uninstall: could not remove the menu entry", ex);
+            }
+        }
+
+        private static void DetachMenuItem(ToolStrip owner, ToolStripItem item)
+        {
+            owner.Items.Remove(item);
+            item.Dispose();
+        }
 
         /// <summary>
         ///     Removes the files that ship beside the plugin assembly. The helper and

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -331,9 +331,15 @@ namespace MusicBeePlugin
         /// </remarks>
         public void Uninstall()
         {
-            // First, and on the UI thread this is called on: the entry is the one
-            // visible trace of the plugin, and leaving it until after the teardown
-            // means it points at nothing for as long as that takes.
+            // Before anything else, because it costs nothing and buys time: the
+            // core's cover build is minutes of blocking work on a first run, and
+            // disposing the host below waits for it. Everything between here and
+            // there is time the build spends stopping instead.
+            _host?.BeginStopping();
+
+            // The entry is the one visible trace of the plugin, so it goes early:
+            // leaving it until after the teardown means it points at nothing for
+            // as long as that takes.
             RemoveMenuItem();
 
             try

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
+using MusicBeePlugin.Ffi;
 using MusicBeePlugin.Host;
 using MusicBeePlugin.Settings;
 using FfiGen = MusicBeePlugin.Ffi.Generated;
@@ -309,10 +310,40 @@ namespace MusicBeePlugin
         }
 
         /// <summary>
-        ///     Cleans up any persisted files during the plugin uninstall.
+        ///     Cleans up after the plugin when the user removes it from MusicBee's
+        ///     Preferences: the two files MusicBee will not remove, and the stored
+        ///     settings, caches and logs.
         /// </summary>
+        /// <remarks>
+        ///     MusicBee deletes mb_remote.dll - the assembly it loaded - and does so at
+        ///     its next start, not now. It has never heard of mbrc_core.dll or
+        ///     mbrc-helper.exe beside it, so removing those is ours to do, and the core
+        ///     cannot be deleted while it is mapped into this process. Hence the order:
+        ///     stop the core, stop logging through it, unmap it, then delete.
+        /// </remarks>
         public void Uninstall()
         {
+            try
+            {
+                SettingsWindow.CloseIfOpen();
+                _host?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Plugin Uninstall: host teardown failed", ex);
+            }
+            finally
+            {
+                _host = null;
+            }
+
+            // Every log line through FfiLogger is a call into the core, so this has
+            // to come before the unload and stay off afterwards.
+            FfiLogger.MarkUnavailable();
+            RemoveInstalledFiles();
+
+            // Last, so that anything the steps above recorded is still removed with
+            // it: LogToFallback writes into this directory.
             try
             {
                 var settingsFolder = Path.Combine(
@@ -324,6 +355,63 @@ namespace MusicBeePlugin
             catch
             {
                 // Best-effort cleanup; never throw out of Uninstall.
+            }
+        }
+
+        /// <summary>
+        ///     Everything the plugin put in MusicBee's Plugins folder except
+        ///     mb_remote.dll, which MusicBee deletes itself. Named so that each one
+        ///     is unmistakably ours: nothing here can be a MusicBee file or another
+        ///     plugin's.
+        /// </summary>
+        private static readonly string[] InstalledFiles =
+        {
+            "mbrc-helper.exe", "MBRC_LICENSE.txt", "MBRC_README.txt",
+        };
+
+        /// <summary>
+        ///     Removes the files that ship beside the plugin assembly. The helper and
+        ///     the text files are not held by anything, so they go unconditionally.
+        ///     The core is deleted only once it is actually unmapped - Windows will
+        ///     not unlink a loaded image, and a failed unload must not turn into a
+        ///     silent failed delete.
+        /// </summary>
+        private void RemoveInstalledFiles()
+        {
+            string directory;
+            try
+            {
+                directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Plugin Uninstall: could not locate the plugin directory", ex);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(directory)) return;
+
+            foreach (var name in InstalledFiles)
+                TryDelete(Path.Combine(directory, name));
+
+            if (NativeBridge.UnloadNativeLibrary())
+                TryDelete(Path.Combine(directory, "mbrc_core.dll"));
+            else
+                LogToFallback(
+                    "Plugin Uninstall: the core is still loaded",
+                    "mbrc_core.dll was left in place because it could not be unmapped");
+        }
+
+        /// <summary>Deletes a file if it is there. Never throws.</summary>
+        private void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Plugin Uninstall: could not remove " + path, ex);
             }
         }
 


### PR DESCRIPTION
Removing the plugin inside MusicBee used to leave `mbrc_core.dll` and
`mbrc-helper.exe` sitting in the Plugins folder. MusicBee only knows about the
assembly it loaded, and the native core was still mapped into the process, so
nothing could delete it. The plugin now cleans up after itself, with MusicBee
still running.

Closes #192.

## What `Uninstall()` does now

1. `BeginStopping()` - a new `mbrc_begin_stopping` FFI call that sets the core's
   stopping flag and returns. It stops nothing itself; it buys the cover build
   notice while the rest of the teardown runs.
2. Detaches the Tools menu entry from its owning `ToolStrip`, so the entry goes
   at once rather than at the next start. `MB_AddMenuItem` hands back a live
   `ToolStripItem` and there is no remove API, so the item is kept in a field
   for exactly this.
3. Closes the settings window, disposes the host, and marks `FfiLogger`
   unavailable - every log line is a call into the core, and the core is about
   to be unloaded.
4. `NativeBridge.UnloadNativeLibrary()` loops `GetModuleHandle`/`FreeLibrary`
   until the handle is null. One `FreeLibrary` is not enough: the CLR holds its
   own `DllImport` reference on top of the plugin's explicit preload. After this
   returns true, any `NativeMethods` call is an access violation, which is why
   it runs last.
5. Deletes `mbrc_core.dll`, `mbrc-helper.exe`, `MBRC_LICENSE.txt`,
   `MBRC_README.txt` and the storage folder. If the unload did not manage to
   clear the handle, the core is left alone and the reason is logged rather
   than the delete being attempted against a mapped image.

`mb_remote.dll` still waits for MusicBee's next start. That one is MusicBee's
delete, not ours.

## Stopping the cover build

Teardown used to freeze MusicBee for the length of a cover build. Dropping a
Tokio multi-thread runtime waits for `spawn_blocking` tasks, so `stop_networking`
sat on the build to completion.

`cover::store::build_until` now takes a `stop` predicate and checks it between
albums: it reports `stopped=true` and keeps what it built, so the next build
picks up the missing covers. The server checks the flag between the metadata and
cover halves too and skips the cover build outright if teardown already started.

The flag is set in `stop_networking` (not only `shutdown`, which is not the path
`PluginHost.Dispose` takes) and cleared in `start_networking`, so a port change -
stop then start on the same core - is unaffected. A one-way flag there would have
silently disabled cover builds for the rest of the session.

## Packaging

The archive shipped `LICENSE` and `README.txt`. On a case-insensitive filesystem
the latter overwrites MusicBee's own `readme.txt` in the Plugins folder, and both
survived every update. They ship as `MBRC_LICENSE.txt` and `MBRC_README.txt` now,
which also gives the uninstall two unambiguous names to delete.

## Tests

- `state::tests::stopping_is_set_for_teardown_and_cleared_for_a_restart` - the
  flag is set by teardown, is idempotent, and a restart clears it.
- `cover::store::tests::build_stops_when_asked_and_keeps_what_it_built` - the
  build gives up between albums, reports `stopped=true`, and keeps the covers it
  had already written.

215 core tests, 83 C# tests, clippy and `dotnet format` clean.

## Live verification

Portable install, MusicBee running throughout the removal: `mbrc_core.dll`,
`mbrc-helper.exe`, `MBRC_LICENSE.txt`, `MBRC_README.txt` and the storage folder
were all gone immediately, the Tools entry disappeared with them, MusicBee's own
`readme.txt` was untouched, and `mb_remote.dll` went at the next start.

The `stopped=true` log line was not read back: the log lives in the storage
folder the uninstall deletes, so that specific evidence goes with it. The
behaviour it records is covered by the test above.

## Note on the base

This branch sits on top of `fix/uninstaller-plugin-paths` (#190), so it carries
that commit too.
