### PR TITLE
fix(core): stop a leaking client locking itself out of the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ shipped Android and iOS client keeps working untouched.
 - Removing the plugin while the cover cache was building froze MusicBee until the
   build finished. Teardown now tells the build to stop first and it gives up
   between albums, keeping what it had already built for next time.
+- The iOS app could stop responding after a couple of minutes of browsing,
+  sitting on a loading spinner while playback controls still worked. It opens a
+  new connection for each thing you do and does not close them, and this version
+  had started refusing new connections once 40 were open from one device, so
+  every later tap was discarded with nothing to show for it. The plugin now
+  closes the oldest abandoned connection to let the new one through, and clears
+  out ones that have been unused for a long time.
 - Debug logs and diagnostics captures showed nothing the plugin pushed on its
   own. Events sent to connected clients and the keepalive pings never reached
   the log, so a capture of a push problem looked identical to a capture of

--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -91,6 +91,10 @@ fn default_max_conns_per_ip() -> usize {
     40
 }
 
+fn default_aux_idle_timeout_secs() -> u64 {
+    300
+}
+
 fn default_tcp_keepalive_secs() -> u64 {
     45
 }
@@ -169,11 +173,21 @@ pub struct Config {
     /// the cap is rejected. A leak backstop for grouped clients (Android v4).
     #[serde(default = "default_max_conns_per_client")]
     pub max_conns_per_client: usize,
-    /// Max concurrent connections from a single source IP (loopback exempt); the
-    /// newest over the cap is rejected. Bounds ungrouped clients (iOS, old
-    /// Android) and, on a LAN, is effectively a per-device leak bound.
+    /// Max concurrent connections from a single source IP (loopback exempt). At
+    /// the cap the least recently active non-subscriber from that IP is evicted
+    /// to admit the newcomer, and only a peer with nothing evictable is refused.
+    /// Bounds ungrouped clients (iOS, old Android) and, on a LAN, is effectively
+    /// a per-device leak bound.
     #[serde(default = "default_max_conns_per_ip")]
     pub max_conns_per_ip: usize,
+    /// How long a handshaked non-subscriber (`no_broadcast`) socket may sit idle
+    /// before it is closed; `0` disables the reap. Broadcast subscribers are
+    /// never reaped at any value. Shipped iOS clients open one of these per user
+    /// action and never close it, so this drains the leak on a long session.
+    /// Generous by design: a short window here is the regime that broke library
+    /// syncs, and the per-IP eviction path is what actually bounds the leak.
+    #[serde(default = "default_aux_idle_timeout_secs")]
+    pub aux_idle_timeout_secs: u64,
     /// OS-level TCP keepalive idle time (seconds) set on each accepted socket so
     /// the kernel detects and drops dead half-open connections.
     #[serde(default = "default_tcp_keepalive_secs")]
@@ -244,6 +258,7 @@ impl Default for Config {
             unhandshaked_timeout_secs: default_unhandshaked_timeout_secs(),
             max_conns_per_client: default_max_conns_per_client(),
             max_conns_per_ip: default_max_conns_per_ip(),
+            aux_idle_timeout_secs: default_aux_idle_timeout_secs(),
             tcp_keepalive_secs: default_tcp_keepalive_secs(),
             mdns_enabled: default_mdns_enabled(),
             update_check_enabled: default_update_check_enabled(),

--- a/packages/mbrc-core/src/diagnostics/report.rs
+++ b/packages/mbrc-core/src/diagnostics/report.rs
@@ -29,6 +29,7 @@ pub fn build(core: &Core, host_env: &[CaptureEnvEntry], started_unix_ms: i64) ->
         "settings": settings(core),
         "listening": listening(core),
         "caches": caches(core),
+        "connections": connections(core),
         "blocked_connections": core.blocked.recent(),
         "update": update(core),
         "process": {
@@ -86,6 +87,25 @@ fn listening(core: &Core) -> Value {
         "bind_address": core.config.bind_address,
         "addresses": addresses,
         "mdns_enabled": core.config.mdns_enabled,
+    })
+}
+
+/// What is connected right now. The blocked list below records refusals, but a
+/// refusal is a symptom: without the live counts a maintainer cannot see the
+/// accumulation that caused it, and a bug reporter has no way to produce it.
+fn connections(core: &Core) -> Value {
+    let stats = core.registry.stats();
+    json!({
+        "total": stats.total,
+        "subscribers": stats.subscribers,
+        "by_ip": stats
+            .by_ip
+            .iter()
+            .map(|(ip, count)| json!({ "ip": ip, "count": count }))
+            .collect::<Vec<_>>(),
+        "oldest_idle_secs": stats.oldest_idle_secs,
+        "evicted_total": stats.evicted_total,
+        "rejected_per_ip_total": stats.rejected_per_ip_total,
     })
 }
 

--- a/packages/mbrc-core/src/server/connection.rs
+++ b/packages/mbrc-core/src/server/connection.rs
@@ -81,6 +81,7 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
     // so dropping it when the ping tick fires loses no bytes.
     let ping_interval = Duration::from_secs(core.config.ping_interval_secs);
     let unhandshaked_timeout = Duration::from_secs(core.config.unhandshaked_timeout_secs);
+    let aux_idle_timeout = Duration::from_secs(core.config.aux_idle_timeout_secs);
     let mut ping_tick = tokio::time::interval(ping_interval);
     ping_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     ping_tick.tick().await; // consume the immediate first tick
@@ -104,15 +105,17 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
                 break;
             }
             _ = ping_tick.tick() => {
-                // Only sockets that connected but never completed the handshake are
-                // idle-reaped (they negotiated nothing). Handshaked sockets - both
-                // broadcast subscribers AND auxiliary request/response channels -
-                // are NEVER idle-reaped, matching the shipped C# plugin: a real
-                // client (iOS especially) keeps its command/event sockets open for
-                // reuse and closes them itself, so reaping them mid-idle is exactly
-                // what breaks its sync / leaves the app non-responsive. Dead sockets
-                // are caught by OS TCP keepalive or the ping send failing; leaks are
-                // bounded by the per-client / per-IP caps.
+                // A socket that connected but never completed the handshake is
+                // reaped quickly (it negotiated nothing). A broadcast subscriber is
+                // never idle-reaped at all, matching the shipped C# plugin: a real
+                // client keeps its event socket open and closes it itself, so
+                // reaping it mid-idle is exactly what breaks sync / leaves the app
+                // non-responsive. Auxiliary channels sit between the two - kept
+                // open for reuse, but closed once abandoned past
+                // `aux_idle_timeout_secs`, which defaults high enough that reuse
+                // still works. Dead sockets are also caught by OS TCP keepalive or
+                // the ping send failing; leaks are bounded by the per-client /
+                // per-IP caps.
                 if session.protocol_version.is_none() {
                     let idle = last_inbound.elapsed();
                     if idle >= unhandshaked_timeout {
@@ -125,10 +128,27 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
                         break;
                     }
                 }
-                // Ping ONLY broadcast subscribers; auxiliary request/response
-                // sockets are never pushed to - matching the shipped C# plugin. A
-                // failed send means a dead socket -> close.
+                // Auxiliary (no_broadcast) sockets get a long idle window of
+                // their own. Shipped iOS clients open one of these per user
+                // action and never close it, so without a drain they accumulate
+                // until the per-IP cap starts refusing. Subscribers are exempt -
+                // reaping those is what broke library syncs - and the window is
+                // deliberately generous, because iOS does reuse some aux sockets.
+                // The per-IP eviction path is what actually guarantees a client
+                // can't lock itself out; this is slow hygiene for long sessions.
                 let subscribes = registered && !session.no_broadcast;
+                if registered && !subscribes && aux_idle_timeout > Duration::ZERO {
+                    let idle = last_inbound.elapsed();
+                    if idle >= aux_idle_timeout {
+                        tracing::debug!(
+                            %peer,
+                            conn_id,
+                            idle_ms = idle.as_millis() as u64,
+                            "closing idle auxiliary connection"
+                        );
+                        break;
+                    }
+                }
                 if subscribes {
                     if out_tx.send(PING_FRAME.to_string()).is_err() {
                         break;
@@ -139,6 +159,9 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
             }
         };
         last_inbound = tokio::time::Instant::now();
+        // Keep the registry's idea of activity current, so the per-IP cap evicts
+        // sockets the client has abandoned rather than ones it is still using.
+        core.registry.touch(conn_id);
         accumulator.push_bytes(&buf[..n]);
 
         while let Some(line) = accumulator.next_frame() {
@@ -167,6 +190,7 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
                 let is_main = !session.no_broadcast;
                 match core.registry.register(
                     conn_id,
+                    peer.ip(),
                     session.client_id.as_deref(),
                     is_main,
                     peer.ip().is_loopback(),
@@ -184,8 +208,10 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
                             core.broadcaster.register(conn_id, out_tx.clone());
                         }
                     }
+                    // WARN for the same reason as the per-IP refusal: the client
+                    // is about to stop working and INFO would say nothing.
                     Admit::RejectedCap => {
-                        tracing::debug!(
+                        tracing::warn!(
                             %peer,
                             conn_id,
                             client_id = session.client_id.as_deref().unwrap_or("none"),
@@ -209,9 +235,9 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
 
         // A frame that blew past the accumulator's cap with no terminator is an
         // unbounded-buffer attack or a badly broken peer. The accumulator has
-        // already dropped the buffered bytes; close the socket (issue #138). A
-        // handshaked socket is never idle-reaped, so this is the only bound on a
-        // handshaked peer that streams a terminator-less flood.
+        // already dropped the buffered bytes; close the socket (issue #138). Such
+        // a peer is never idle by the reaper's reckoning - it is sending
+        // constantly - so this is the only bound on it.
         if accumulator.overflowed() {
             tracing::warn!(
                 %peer,

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -544,12 +544,28 @@ async fn accept_loop(listener: TcpListener, core: Arc<Core>) {
                 }
                 // Per-IP connection cap (loopback exempt). Reserve the slot here
                 // so it pairs with the release after the connection ends.
-                if !core.registry.try_admit_ip(peer.ip()) {
-                    tracing::debug!(%peer, "rejecting client: per-IP connection cap reached");
-                    core.blocked
-                        .record(peer.ip(), peer.port(), blocked::BlockReason::PerIpCap);
-                    tokio::spawn(reject_client(stream));
-                    continue;
+                match core.registry.admit_ip(peer.ip()) {
+                    registry::IpAdmit::Admitted => {}
+                    registry::IpAdmit::Evicted(victim) => {
+                        tracing::debug!(
+                            %peer,
+                            victim,
+                            "per-IP cap reached; evicted an idle connection to admit this one"
+                        );
+                    }
+                    // WARN, not DEBUG: this is the point where the user's app
+                    // stops working, and at the default INFO level a DEBUG line
+                    // meant their log said nothing at all about it.
+                    registry::IpAdmit::Rejected => {
+                        tracing::warn!(
+                            %peer,
+                            "rejecting client: per-IP connection cap reached, nothing idle to evict"
+                        );
+                        core.blocked
+                            .record(peer.ip(), peer.port(), blocked::BlockReason::PerIpCap);
+                        tokio::spawn(reject_client(stream));
+                        continue;
+                    }
                 }
                 tokio::spawn(async move {
                     // Release the reserved per-IP slot on drop, so it is returned

--- a/packages/mbrc-core/src/server/registry.rs
+++ b/packages/mbrc-core/src/server/registry.rs
@@ -6,6 +6,11 @@
 //! normal recycling is handled by the per-connection idle-timeout + OS TCP
 //! keepalive, and this registry only catches a runaway before it accumulates.
 //!
+//! Catching a runaway means evicting, not refusing. Shipped iOS clients open a
+//! socket per user action and never close it; turning the newest one away just
+//! discards the user's request, so at the cap the stalest non-subscriber from
+//! that IP is closed to make room instead.
+//!
 //! Two identities per connection: the server-assigned `conn_id` and the optional
 //! client-provided `client_id` (Android v4 sends a UUID; iOS and old Android send
 //! none). When a `client_id` is present we can group its sockets - enforce a
@@ -14,9 +19,16 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use tokio::sync::Notify;
+
+/// How long a connection must have been silent before the per-IP cap may evict
+/// it. Well above a request's round trip, so a socket that is mid-exchange is
+/// never taken; the sockets this actually frees have been silent for minutes.
+const MIN_EVICT_IDLE_MS: u64 = 10_000;
 
 /// Result of registering a handshaked connection.
 #[derive(Debug, PartialEq, Eq)]
@@ -27,6 +39,33 @@ pub enum Admit {
     RejectedCap,
 }
 
+/// Result of reserving a per-IP slot at accept time.
+#[derive(Debug, PartialEq, Eq)]
+pub enum IpAdmit {
+    /// A slot was free.
+    Admitted,
+    /// The IP was at its cap, so this stale connection was closed to make room.
+    /// Its slot is released asynchronously when its task finishes.
+    Evicted(u64),
+    /// At the cap with nothing worth evicting; the caller rejects the peer.
+    Rejected,
+}
+
+/// What the registry can say about itself for a diagnostics report.
+pub struct RegistryStats {
+    /// Handshaked connections currently held.
+    pub total: usize,
+    /// How many of those are broadcast subscribers.
+    pub subscribers: usize,
+    /// Reserved per-IP slots (includes sockets that never handshaked), busiest
+    /// first.
+    pub by_ip: Vec<(String, usize)>,
+    /// How long the most neglected connection has been silent.
+    pub oldest_idle_secs: u64,
+    pub evicted_total: u64,
+    pub rejected_per_ip_total: u64,
+}
+
 /// The live sockets of one `client_id`.
 #[derive(Default)]
 struct ClientEntry {
@@ -35,18 +74,43 @@ struct ClientEntry {
     main: Option<u64>,
 }
 
+/// What the registry keeps about one handshaked connection, so the per-IP cap
+/// can pick a victim rather than turning the newcomer away.
+struct ConnMeta {
+    ip: IpAddr,
+    /// Broadcast subscribers are never evicted: losing one silently stops every
+    /// push to that client, which is far worse than refusing a socket.
+    is_main: bool,
+    /// Millis since [`ConnectionRegistry::origin`] of the last inbound frame.
+    last_active_ms: u64,
+    shutdown: Arc<Notify>,
+}
+
 #[derive(Default)]
 struct Inner {
     by_ip: HashMap<IpAddr, usize>,
     by_client: HashMap<String, ClientEntry>,
     /// Per-connection close signal, fired to supersede a stale main.
     shutdown: HashMap<u64, Arc<Notify>>,
+    /// Handshaked connections, for eviction. An un-handshaked socket holds an IP
+    /// slot but is absent here; those are already reaped at
+    /// `unhandshaked_timeout_secs`, so they need no eviction path.
+    conns: HashMap<u64, ConnMeta>,
 }
 
 pub struct ConnectionRegistry {
     max_conns_per_client: usize,
     max_conns_per_ip: usize,
     inner: Mutex<Inner>,
+    /// Monotonic zero for `last_active_ms`. A monotonic clock, not the wall
+    /// clock, so a system time change can't make a connection look ancient.
+    origin: Instant,
+    evicted_total: AtomicU64,
+    rejected_per_ip_total: AtomicU64,
+    /// Test-only clock offset, so idle-ageing tests advance time instead of
+    /// sleeping for the eviction threshold.
+    #[cfg(test)]
+    test_offset_ms: AtomicU64,
 }
 
 impl ConnectionRegistry {
@@ -55,7 +119,26 @@ impl ConnectionRegistry {
             max_conns_per_client,
             max_conns_per_ip,
             inner: Mutex::new(Inner::default()),
+            origin: Instant::now(),
+            evicted_total: AtomicU64::new(0),
+            rejected_per_ip_total: AtomicU64::new(0),
+            #[cfg(test)]
+            test_offset_ms: AtomicU64::new(0),
         }
+    }
+
+    /// Millis since the registry's origin.
+    fn now_ms(&self) -> u64 {
+        let now = self.origin.elapsed().as_millis() as u64;
+        #[cfg(test)]
+        let now = now + self.test_offset_ms.load(Ordering::Relaxed);
+        now
+    }
+
+    /// Move the clock forward, ageing every recorded connection at once.
+    #[cfg(test)]
+    fn advance(&self, ms: u64) {
+        self.test_offset_ms.fetch_add(ms, Ordering::Relaxed);
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
@@ -63,19 +146,68 @@ impl ConnectionRegistry {
     }
 
     /// Reserve an IP slot at accept time. Loopback is always admitted (local
-    /// tooling / the same-host debugger are never capped). Returns `false` when
-    /// the IP is at its cap, in which case the caller rejects the connection.
-    pub fn try_admit_ip(&self, ip: IpAddr) -> bool {
+    /// tooling / the same-host debugger are never capped).
+    ///
+    /// At the cap this evicts rather than refusing, when it can. Refusing the
+    /// newest socket is the wrong answer to a client that leaks: the newcomer is
+    /// the one carrying the user's request, while the sockets already held are
+    /// the abandoned ones. Shipped iOS clients open a socket per user action and
+    /// never close it, so without this they walk into the cap and every later
+    /// action is silently discarded (the app spins forever). The C# plugin had no
+    /// cap at all and absorbed the leak; evicting keeps the bound without
+    /// reintroducing that lockout.
+    ///
+    /// The victim is the least recently active non-subscriber from the same IP
+    /// that has been silent for at least [`MIN_EVICT_IDLE_MS`]. Its slot is
+    /// released when its task actually finishes, so the count sits one over the
+    /// cap until then; the overshoot is bounded by evictions in flight.
+    pub fn admit_ip(&self, ip: IpAddr) -> IpAdmit {
         if ip.is_loopback() {
-            return true;
+            return IpAdmit::Admitted;
         }
+        let now = self.now_ms();
         let mut inner = self.lock();
         let count = inner.by_ip.entry(ip).or_insert(0);
-        if *count >= self.max_conns_per_ip {
-            return false;
+        if *count < self.max_conns_per_ip {
+            *count += 1;
+            return IpAdmit::Admitted;
         }
-        *count += 1;
-        true
+        let Some(victim) = Self::evictable(&inner, ip, now) else {
+            self.rejected_per_ip_total.fetch_add(1, Ordering::Relaxed);
+            return IpAdmit::Rejected;
+        };
+        if let Some(meta) = inner.conns.get(&victim) {
+            meta.shutdown.notify_one();
+        }
+        *inner.by_ip.entry(ip).or_insert(0) += 1;
+        self.evicted_total.fetch_add(1, Ordering::Relaxed);
+        IpAdmit::Evicted(victim)
+    }
+
+    /// The connection this IP can most afford to lose, if any.
+    fn evictable(inner: &Inner, ip: IpAddr, now: u64) -> Option<u64> {
+        inner
+            .conns
+            .iter()
+            .filter(|(_, meta)| {
+                meta.ip == ip
+                    && !meta.is_main
+                    && now.saturating_sub(meta.last_active_ms) >= MIN_EVICT_IDLE_MS
+            })
+            .min_by_key(|(conn_id, meta)| (meta.last_active_ms, **conn_id))
+            .map(|(conn_id, _)| *conn_id)
+    }
+
+    /// Record inbound activity, so eviction prefers genuinely abandoned sockets
+    /// over ones the client is still using. Called per inbound frame; frames run
+    /// at a few hundred per session, so taking the lock here is cheaper than
+    /// plumbing a shared atomic through every connection.
+    pub fn touch(&self, conn_id: u64) {
+        let now = self.now_ms();
+        let mut inner = self.lock();
+        if let Some(meta) = inner.conns.get_mut(&conn_id) {
+            meta.last_active_ms = now;
+        }
     }
 
     /// Release the IP slot reserved by [`try_admit_ip`](Self::try_admit_ip) when
@@ -101,15 +233,29 @@ impl ConnectionRegistry {
     pub fn register(
         &self,
         conn_id: u64,
+        ip: IpAddr,
         client_id: Option<&str>,
         is_main: bool,
         loopback: bool,
         shutdown: Arc<Notify>,
     ) -> Admit {
+        let now = self.now_ms();
         let mut inner = self.lock();
 
         let Some(client_id) = client_id else {
-            inner.shutdown.insert(conn_id, shutdown);
+            inner.shutdown.insert(conn_id, shutdown.clone());
+            // Ungrouped connections are exactly the ones that need the eviction
+            // path: with no client_id there is no per-client cap holding them
+            // back, so the per-IP cap is their only bound.
+            inner.conns.insert(
+                conn_id,
+                ConnMeta {
+                    ip,
+                    is_main,
+                    last_active_ms: now,
+                    shutdown,
+                },
+            );
             return Admit::Admitted;
         };
 
@@ -126,7 +272,16 @@ impl ConnectionRegistry {
             }
         };
 
-        inner.shutdown.insert(conn_id, shutdown);
+        inner.shutdown.insert(conn_id, shutdown.clone());
+        inner.conns.insert(
+            conn_id,
+            ConnMeta {
+                ip,
+                is_main,
+                last_active_ms: now,
+                shutdown,
+            },
+        );
 
         // Wake the superseded main's task so it closes. `notify_one` stores a
         // permit if the task isn't awaiting yet, so there is no lost-wakeup race.
@@ -144,6 +299,9 @@ impl ConnectionRegistry {
     pub fn unregister(&self, conn_id: u64, client_id: Option<&str>) {
         let mut inner = self.lock();
         inner.shutdown.remove(&conn_id);
+        // Drop the eviction entry too, so a closed connection is never chosen as
+        // a victim (its `Notify` would fire into nothing and free no slot).
+        inner.conns.remove(&conn_id);
         let Some(client_id) = client_id else {
             return;
         };
@@ -158,6 +316,34 @@ impl ConnectionRegistry {
         };
         if now_empty {
             inner.by_client.remove(client_id);
+        }
+    }
+
+    /// A snapshot of what is connected, for `report.json`. Without this a bug
+    /// report shows the refusals but not the accumulation that caused them,
+    /// which is the half that actually names the problem.
+    pub fn stats(&self) -> RegistryStats {
+        let now = self.now_ms();
+        let inner = self.lock();
+        let mut by_ip: Vec<(String, usize)> = inner
+            .by_ip
+            .iter()
+            .map(|(ip, count)| (ip.to_string(), *count))
+            .collect();
+        // Busiest first: the runaway client is the one worth seeing.
+        by_ip.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        RegistryStats {
+            total: inner.conns.len(),
+            subscribers: inner.conns.values().filter(|m| m.is_main).count(),
+            by_ip,
+            oldest_idle_secs: inner
+                .conns
+                .values()
+                .map(|m| now.saturating_sub(m.last_active_ms) / 1000)
+                .max()
+                .unwrap_or(0),
+            evicted_total: self.evicted_total.load(Ordering::Relaxed),
+            rejected_per_ip_total: self.rejected_per_ip_total.load(Ordering::Relaxed),
         }
     }
 
@@ -185,19 +371,22 @@ mod tests {
     fn notify() -> Arc<Notify> {
         Arc::new(Notify::new())
     }
+    /// Idle long enough for the per-IP cap to consider evicting.
+    const STALE: u64 = MIN_EVICT_IDLE_MS + 1_000;
 
     #[test]
     fn per_ip_cap_admits_up_to_limit_then_rejects() {
         let r = ConnectionRegistry::new(20, 3);
         let peer = ip("192.168.1.5");
-        assert!(r.try_admit_ip(peer));
-        assert!(r.try_admit_ip(peer));
-        assert!(r.try_admit_ip(peer));
-        assert!(!r.try_admit_ip(peer), "4th over the cap of 3");
+        assert_eq!(r.admit_ip(peer), IpAdmit::Admitted);
+        assert_eq!(r.admit_ip(peer), IpAdmit::Admitted);
+        assert_eq!(r.admit_ip(peer), IpAdmit::Admitted);
+        // Nothing handshaked, so there is nothing to evict: still a refusal.
+        assert_eq!(r.admit_ip(peer), IpAdmit::Rejected, "4th over the cap of 3");
         assert_eq!(r.ip_count(peer), 3);
         // Releasing frees a slot.
         r.release_ip(peer);
-        assert!(r.try_admit_ip(peer));
+        assert_eq!(r.admit_ip(peer), IpAdmit::Admitted);
     }
 
     #[test]
@@ -205,24 +394,150 @@ mod tests {
         let r = ConnectionRegistry::new(20, 2);
         let lo = ip("127.0.0.1");
         for _ in 0..10 {
-            assert!(r.try_admit_ip(lo));
+            assert_eq!(r.admit_ip(lo), IpAdmit::Admitted);
         }
         assert_eq!(r.ip_count(lo), 0, "loopback is not counted");
+    }
+
+    /// The fix for the iOS lockout: at the cap, the socket the client abandoned
+    /// longest ago goes, and the newcomer carrying the user's request gets in.
+    #[test]
+    fn at_the_cap_the_stalest_connection_is_evicted_not_the_newcomer() {
+        let r = ConnectionRegistry::new(20, 2);
+        let peer = ip("192.168.1.5");
+        assert_eq!(r.admit_ip(peer), IpAdmit::Admitted);
+        assert_eq!(r.admit_ip(peer), IpAdmit::Admitted);
+        // conn 1 goes quiet 5s before conn 2 does.
+        r.register(1, peer, None, false, false, notify());
+        r.advance(5_000);
+        r.register(2, peer, None, false, false, notify());
+        r.advance(STALE);
+
+        assert_eq!(r.admit_ip(peer), IpAdmit::Evicted(1));
+        assert_eq!(r.stats().evicted_total, 1);
+        assert_eq!(r.stats().rejected_per_ip_total, 0);
+    }
+
+    /// Evicting the broadcast socket would silently kill every push to that
+    /// client, which is worse than refusing a connection. It is never a victim,
+    /// even when it is the least recently active thing on the IP.
+    #[test]
+    fn a_broadcast_subscriber_is_never_evicted() {
+        let r = ConnectionRegistry::new(20, 2);
+        let peer = ip("192.168.1.5");
+        r.admit_ip(peer);
+        r.admit_ip(peer);
+        r.register(1, peer, None, true, false, notify()); // the subscriber
+        r.advance(60_000); // by far the stalest
+        r.register(2, peer, None, false, false, notify());
+        r.advance(STALE);
+
+        assert_eq!(r.admit_ip(peer), IpAdmit::Evicted(2));
+    }
+
+    /// A socket that just spoke may be mid-exchange, so it is not a candidate.
+    /// With nothing else to take, the old refusal behaviour stands.
+    #[test]
+    fn a_recently_active_connection_is_not_evicted() {
+        let r = ConnectionRegistry::new(20, 1);
+        let peer = ip("192.168.1.5");
+        r.admit_ip(peer);
+        r.register(1, peer, None, false, false, notify());
+
+        assert_eq!(r.admit_ip(peer), IpAdmit::Rejected);
+        assert_eq!(r.stats().rejected_per_ip_total, 1);
+        // Once it has gone quiet it becomes fair game.
+        r.advance(STALE);
+        assert_eq!(r.admit_ip(peer), IpAdmit::Evicted(1));
+    }
+
+    #[test]
+    fn touch_moves_a_connection_out_of_the_firing_line() {
+        let r = ConnectionRegistry::new(20, 2);
+        let peer = ip("192.168.1.5");
+        r.admit_ip(peer);
+        r.admit_ip(peer);
+        r.register(1, peer, None, false, false, notify());
+        r.advance(5_000);
+        r.register(2, peer, None, false, false, notify());
+        r.advance(STALE);
+        // conn 1 speaks up, so conn 2 is now the stalest.
+        r.touch(1);
+
+        assert_eq!(r.admit_ip(peer), IpAdmit::Evicted(2));
+    }
+
+    #[test]
+    fn eviction_never_crosses_ip_boundaries() {
+        let r = ConnectionRegistry::new(20, 1);
+        let noisy = ip("192.168.1.5");
+        let quiet = ip("192.168.1.6");
+        r.admit_ip(noisy);
+        r.admit_ip(quiet);
+        r.register(1, quiet, None, false, false, notify());
+        r.advance(60_000); // conn 1 is stalest overall, but on a different IP
+        r.register(2, noisy, None, false, false, notify());
+        r.advance(STALE);
+
+        assert_eq!(r.admit_ip(noisy), IpAdmit::Evicted(2));
+    }
+
+    #[test]
+    fn a_closed_connection_is_not_a_victim() {
+        let r = ConnectionRegistry::new(20, 1);
+        let peer = ip("192.168.1.5");
+        r.admit_ip(peer);
+        r.register(1, peer, None, false, false, notify());
+        r.advance(STALE);
+        r.unregister(1, None);
+
+        assert_eq!(
+            r.admit_ip(peer),
+            IpAdmit::Rejected,
+            "conn 1 is gone; notifying it would free no slot"
+        );
+    }
+
+    #[test]
+    fn stats_report_what_is_connected() {
+        let r = ConnectionRegistry::new(20, 40);
+        let a = ip("192.168.1.5");
+        let b = ip("192.168.1.6");
+        r.admit_ip(a);
+        r.admit_ip(a);
+        r.admit_ip(b);
+        r.register(1, a, None, true, false, notify());
+        r.register(2, a, None, false, false, notify());
+        r.register(3, b, None, false, false, notify());
+        // Only conn 2 stays quiet across the next 30 seconds.
+        r.advance(30_000);
+        r.touch(1);
+        r.touch(3);
+
+        let stats = r.stats();
+        assert_eq!(stats.total, 3);
+        assert_eq!(stats.subscribers, 1);
+        assert_eq!(
+            stats.by_ip[0],
+            ("192.168.1.5".to_string(), 2),
+            "busiest first"
+        );
+        assert_eq!(stats.oldest_idle_secs, 30);
     }
 
     #[test]
     fn per_client_cap_rejects_newest() {
         let r = ConnectionRegistry::new(2, 40);
         assert_eq!(
-            r.register(1, Some("cX"), false, false, notify()),
+            r.register(1, ip("10.0.0.1"), Some("cX"), false, false, notify()),
             Admit::Admitted
         );
         assert_eq!(
-            r.register(2, Some("cX"), false, false, notify()),
+            r.register(2, ip("10.0.0.1"), Some("cX"), false, false, notify()),
             Admit::Admitted
         );
         assert_eq!(
-            r.register(3, Some("cX"), false, false, notify()),
+            r.register(3, ip("10.0.0.1"), Some("cX"), false, false, notify()),
             Admit::RejectedCap,
             "3rd over the per-client cap of 2"
         );
@@ -230,7 +545,7 @@ mod tests {
         // A rejected conn was not recorded; freeing one admits again.
         r.unregister(1, Some("cX"));
         assert_eq!(
-            r.register(4, Some("cX"), false, false, notify()),
+            r.register(4, ip("10.0.0.1"), Some("cX"), false, false, notify()),
             Admit::Admitted
         );
     }
@@ -240,7 +555,7 @@ mod tests {
         let r = ConnectionRegistry::new(2, 40);
         for id in 0..10 {
             assert_eq!(
-                r.register(id, None, false, false, notify()),
+                r.register(id, ip("10.0.0.1"), None, false, false, notify()),
                 Admit::Admitted
             );
         }
@@ -251,12 +566,12 @@ mod tests {
         let r = ConnectionRegistry::new(20, 40);
         let old = notify();
         assert_eq!(
-            r.register(1, Some("cX"), true, false, old.clone()),
+            r.register(1, ip("10.0.0.1"), Some("cX"), true, false, old.clone()),
             Admit::Admitted
         );
         // A second main for the same client fires the old main's shutdown.
         assert_eq!(
-            r.register(2, Some("cX"), true, false, notify()),
+            r.register(2, ip("10.0.0.1"), Some("cX"), true, false, notify()),
             Admit::Admitted
         );
         // The old main's notify was signalled (permit stored) -> ready now.
@@ -268,7 +583,7 @@ mod tests {
     #[test]
     fn unregister_cleans_empty_client_entries() {
         let r = ConnectionRegistry::new(20, 40);
-        r.register(1, Some("cX"), true, false, notify());
+        r.register(1, ip("10.0.0.1"), Some("cX"), true, false, notify());
         assert_eq!(r.client_count("cX"), 1);
         r.unregister(1, Some("cX"));
         assert_eq!(r.client_count("cX"), 0);

--- a/packages/mbrc-core/tests/handshake.rs
+++ b/packages/mbrc-core/tests/handshake.rs
@@ -226,11 +226,15 @@ fn broadcast_subscriber_is_not_reaped_while_silent() {
 #[test]
 fn aux_socket_gets_no_ping_and_is_not_reaped_while_idle() {
     // An auxiliary request/response socket (no_broadcast=true) must NOT be pinged
-    // (matching C#: only broadcast subscribers are pushed to), AND must not be
-    // idle-reaped once handshaked - a real client (iOS especially) keeps its
-    // command sockets open for reuse. Reaping them mid-idle is what left the app
-    // non-responsive. Only un-handshaked sockets are reaped; dead ones are caught
-    // by TCP keepalive.
+    // (matching C#: only broadcast subscribers are pushed to), and must survive
+    // the *un-handshaked* window - a real client (iOS especially) keeps its
+    // command sockets open for reuse, and reaping them mid-idle is what left the
+    // app non-responsive.
+    //
+    // An aux socket is not immortal: `aux_idle_timeout_secs` closes one that has
+    // been abandoned (see `reaps_idle_auxiliary_connection_after_the_handshake`).
+    // This test leaves that setting at its default 300s, so the window here is
+    // far too short to reach it and the reuse guarantee is what is under test.
     let port = free_port();
     let core = Arc::new(Core::new(
         Arc::new(NullProviders),
@@ -394,4 +398,124 @@ fn broadcast_reaches_a_handshaked_client() {
     );
 
     net.stop();
+}
+
+/// The iOS lockout's other half: shipped clients open a `no_broadcast` command
+/// socket per user action and never close it. Those must drain on their own, or
+/// they pile up until the per-IP cap starts refusing new ones.
+#[test]
+fn reaps_idle_auxiliary_connection_after_the_handshake() {
+    let port = free_port();
+    let core = Arc::new(Core::new(
+        Arc::new(NullProviders),
+        Config {
+            ping_interval_secs: 1,
+            aux_idle_timeout_secs: 2,
+            ..Config::for_test(port)
+        },
+    ));
+    let net = server::start(core).expect("server should bind and start");
+
+    let mut writer = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    let reader_stream = writer.try_clone().unwrap();
+    reader_stream
+        .set_read_timeout(Some(Duration::from_secs(8)))
+        .unwrap();
+    let mut reader = BufReader::new(reader_stream);
+
+    // Handshake as a command socket (no_broadcast), then fall silent - exactly
+    // what the iOS client does after its one command.
+    writer
+        .write_all(
+            concat!(
+                r#"{"context":"player","data":"iOS"}"#,
+                "\r\n",
+                r#"{"context":"protocol","data":{"protocol_version":4,"no_broadcast":true}}"#,
+                "\r\n",
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    for _ in 0..2 {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("handshake reply");
+    }
+
+    let mut line = String::new();
+    let n = reader
+        .read_line(&mut line)
+        .expect("read should end in EOF, not error");
+    net.stop();
+
+    assert_eq!(
+        n, 0,
+        "an abandoned no_broadcast socket should be closed once idle past \
+         aux_idle_timeout_secs, got {line:?}"
+    );
+}
+
+/// The reaper must not touch the event channel. Closing a subscriber silently
+/// stops every push to that client, which is the failure the never-idle-reap
+/// rule exists to prevent.
+#[test]
+fn aux_reaper_leaves_a_broadcast_subscriber_alone() {
+    let port = free_port();
+    let core = Arc::new(Core::new(
+        Arc::new(NullProviders),
+        Config {
+            ping_interval_secs: 1,
+            aux_idle_timeout_secs: 1,
+            ..Config::for_test(port)
+        },
+    ));
+    let net = server::start(core.clone()).expect("server should bind and start");
+
+    let mut writer = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    let reader_stream = writer.try_clone().unwrap();
+    reader_stream
+        .set_read_timeout(Some(Duration::from_secs(8)))
+        .unwrap();
+    let mut reader = BufReader::new(reader_stream);
+
+    writer
+        .write_all(
+            concat!(
+                r#"{"context":"player","data":"Android"}"#,
+                "\r\n",
+                r#"{"context":"protocol","data":{"protocol_version":4,"no_broadcast":false}}"#,
+                "\r\n",
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    for _ in 0..2 {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("handshake reply");
+    }
+
+    // Stay silent well past the aux window, then prove the socket still works by
+    // pushing to it. Server pings arrive on the way; skip them.
+    std::thread::sleep(Duration::from_secs(4));
+    core.broadcaster
+        .broadcast(&[r#"{"context":"playermute","data":true}"#.to_string()]);
+
+    let deadline = Instant::now() + Duration::from_secs(6);
+    let mut got_broadcast = false;
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => panic!("the subscriber was reaped; broadcasts to it are now silently lost"),
+            Ok(_) => {
+                let v: Value = serde_json::from_str(line.trim()).expect("frame is JSON");
+                if v["context"] == "playermute" {
+                    got_broadcast = true;
+                    break;
+                }
+            }
+            Err(e) => panic!("subscriber read failed: {e}"),
+        }
+    }
+
+    net.stop();
+    assert!(got_broadcast, "subscriber should still receive broadcasts");
 }


### PR DESCRIPTION
## The problem

Shipped iOS clients open a fresh TCP socket per user action and never close it. A live capture on 2026-08-30 caught the consequence:

- 40 sockets from one device, **zero ever closed** (not one `connection closed` line in the whole log)
- the 40th accepted at 10:58:47, first refusal at 10:59:01, **16 refusals** and **zero connections accepted** for the rest of the session
- 97 seconds of ordinary browsing to get there

The app does not show an error, it spins. `reject_client` writes `notallowed` and shuts the socket before the client ever sends its request, so the command is discarded rather than refused, while the sockets already open keep now-playing and volume responsive. It reads as "loading forever", not as a connection fault.

## Why it is a 1.5.0 regression

The C# plugin had no cap. `SocketServer.cs` (at `620936e^`) holds sockets in an unbounded `ConcurrentDictionary`, removed only on disconnect, and the only number in `NetworkConstants.cs` is `SocketBacklogSize = 10`, which is the pending-accept queue. 1.4.1 absorbed the leak silently. 1.5.0 added `max_conns_per_ip = 40`, and the per-client cap of 20 never engages because iOS sends no `client_id`.

Shipped V4 clients cannot be fixed retroactively, so the plugin has to tolerate this.

## The change

**Evict instead of refuse.** At the cap the registry closes the least recently active non-subscriber from that IP and admits the newcomer; only a peer with nothing evictable is still refused. The newcomer is the socket carrying the user's request; the ones already held are the abandoned ones. Broadcast subscribers are never evictable, since losing one silently stops every push to that client. A victim must have been silent at least 10s so a socket mid-exchange is never taken, and its slot is released when its task ends, leaving the count one over the cap briefly.

**Drain abandoned command sockets.** A handshaked `no_broadcast` socket idle past the new `aux_idle_timeout_secs` (300s, `0` disables) is closed. Subscribers are exempt at any value, and must be: iOS never answers a ping (0 pongs against 105 pings in a 30 minute session), so a subscriber's inbound activity never advances after the handshake and any window would kill it on the first tick. This narrows the never-idle-reap rule rather than lifting it.

**Refusals log at WARN**, here and for the per-client cap. At the default INFO level the old DEBUG lines meant a user whose app had stopped working had nothing in their log to show for it.

**`report.json` gains a `connections` section** (total, subscribers, per-IP busiest first, oldest idle, evictions, refusals). The blocked list already recorded the refusals, but a refusal is a symptom; without live counts the accumulation behind it is invisible to anyone reading a bug report. Diagnosing this one needed `netstat` and the absence of close lines, neither of which a reporter can send.

## Verification

Unit: 8 new registry tests (stalest evicted not the newcomer, subscriber never a victim, recently-active spared then evicted once quiet, `touch` reorders preference, eviction never crosses IPs, closed connection never picked, counters, stats shape). Integration: an abandoned `no_broadcast` socket gets closed; a subscriber survives the reaper and still receives broadcasts. Full suite green, `fmt` and `clippy -D warnings` clean.

Live, 30 minute iOS session on the portable install:

| | before | after |
|---|---|---|
| per-IP refusals | 16 | **0** |
| connections closed | 0 | 52 of 58 opened |
| peak concurrent | 40 (the cap) | **31** |
| WARN/ERROR | 0 | 0 |

44 sockets drained, all between 300.0s and 315.0s idle with no premature closes, 42 of them the 3-frame one-shot sockets. 538 broadcasts, **every one at `subscribers=1`** — the reaper never touched a subscriber. The app stayed responsive throughout with no hangs.

The session also produced a harder test than planned: the iOS app crashed at 20:36:56 (client-side; eight sockets FIN within 0.4ms, no reap within ten minutes either side, plugin replies all valid up to that point). It reconnected 20 seconds later and broadcasts resumed on the new subscriber with no intervention.

**Not proven live: eviction itself never fired.** The 300s drain kept concurrency below the cap, so that path rests on its unit tests. Reaching it needs a burst denser than 40 actions per 5 minutes.

## Follow-ups, not in this PR

- `oldest_idle_secs` reports the subscriber, which is silent by design, so it reads high on a healthy connection. Worth excluding subscribers or splitting the field.
- Spans created before a capture raises the log level stay inert, so connections predating a capture lose their `conn_id` on every later line. Separate issue.
