### PR TITLE
fix(core): make a diagnostics capture attribute and count connections honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ shipped Android and iOS client keeps working untouched.
   every later tap was discarded with nothing to show for it. The plugin now
   closes the oldest abandoned connection to let the new one through, and clears
   out ones that have been unused for a long time.
+- A diagnostics capture could not tell which connection a frame belonged to, for
+  any connection that was already open when the capture started - usually
+  including the one carrying events. Those frames are now labelled like the
+  rest, and the connection summary in the report no longer counts an idle event
+  channel as a stalled connection.
 - Debug logs and diagnostics captures showed nothing the plugin pushed on its
   own. Events sent to connected clients and the keepalive pings never reached
   the log, so a capture of a push problem looked identical to a capture of

--- a/packages/mbrc-core/src/diagnostics/report.rs
+++ b/packages/mbrc-core/src/diagnostics/report.rs
@@ -96,14 +96,16 @@ fn listening(core: &Core) -> Value {
 fn connections(core: &Core) -> Value {
     let stats = core.registry.stats();
     json!({
-        "total": stats.total,
+        "handshaked": stats.handshaked,
         "subscribers": stats.subscribers,
-        "by_ip": stats
-            .by_ip
+        "unhandshaked": stats.unhandshaked,
+        "slots_by_ip": stats
+            .slots_by_ip
             .iter()
             .map(|(ip, count)| json!({ "ip": ip, "count": count }))
             .collect::<Vec<_>>(),
-        "oldest_idle_secs": stats.oldest_idle_secs,
+        "oldest_aux_idle_secs": stats.oldest_aux_idle_secs,
+        "subscriber_idle_secs": stats.subscriber_idle_secs,
         "evicted_total": stats.evicted_total,
         "rejected_per_ip_total": stats.rejected_per_ip_total,
     })

--- a/packages/mbrc-core/src/server/connection.rs
+++ b/packages/mbrc-core/src/server/connection.rs
@@ -26,6 +26,29 @@ use crate::state::Core;
 /// fails fast on a half-open socket (the send errors, closing the connection).
 const PING_FRAME: &str = r#"{"context":"ping","data":""}"#;
 
+/// Tag every frame/decision emitted while handling one socket with its
+/// `conn_id`, so the interleaved wire log (many overlapping iOS sockets) can be
+/// attributed to a single connection. `peer` stays on the open/close lines.
+///
+/// Deliberately INFO, not DEBUG. A span caches whether it is enabled **when it
+/// is constructed** and never re-evaluates it, and the reload layer cannot
+/// revive one that was born as `Span::none()`. A diagnostics capture raises the
+/// level only after the fact, so a DEBUG span left every connection that already
+/// existed permanently unattributable - including the long-lived broadcast
+/// socket, the one a push-path investigation is actually about. Measured on
+/// 2026-08-30: the subscriber contributed zero attributed lines across sixteen
+/// minutes, while a connection opened after the raise carried its `conn_id`
+/// throughout.
+///
+/// INFO is the floor of every filter the plugin installs (both `logging::init`
+/// fallbacks and all three levels in `capture.rs` / `NativeBridge.SetLogLevel`),
+/// so the span is always live. The span emits nothing itself; its level only
+/// decides whether it exists, which costs one span per connection and nothing
+/// per frame.
+fn conn_span(conn_id: u64) -> tracing::Span {
+    tracing::info_span!("conn", conn_id)
+}
+
 /// Log a keepalive ping on the same `mbrc::wire` target as every other frame.
 /// Pings are pushed, not replies, so nothing else in the wire log would show
 /// them; without this a capture can't tell a quiet client from a dead one.
@@ -62,10 +85,7 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
     let writer_task = tokio::spawn(writer_loop(writer, out_rx));
 
     let conn_id = core.next_conn_id();
-    // Tag every frame/decision emitted while handling this socket with its
-    // conn_id, so the interleaved wire log (many overlapping iOS sockets) can be
-    // attributed to a single connection. peer stays on the open/close lines.
-    let conn_span = tracing::debug_span!("conn", conn_id);
+    let conn_span = conn_span(conn_id);
     let mut session = Session::default();
     let mut accumulator = FrameAccumulator::default();
     let mut buf = [0u8; 4096];
@@ -290,6 +310,28 @@ async fn writer_loop(mut writer: OwnedWriteHalf, mut out_rx: UnboundedReceiver<S
 mod tests {
     use super::*;
     use crate::logging::test_support::capture_wire_lines;
+
+    /// The regression guard for attribution across a level change. A span caches
+    /// whether it is enabled at construction and can never be revived, so a span
+    /// born while the filter sat at INFO - which is where it sits until a
+    /// capture raises it - has to be live at INFO or every connection that
+    /// predates the capture loses its `conn_id` for good. A `debug_span!` here
+    /// fails this.
+    #[test]
+    fn the_conn_span_survives_being_created_before_a_capture() {
+        let at_info = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(std::io::sink)
+            .finish();
+
+        tracing::subscriber::with_default(at_info, || {
+            assert!(
+                !conn_span(1).is_disabled(),
+                "the conn span must be live at INFO, or a capture cannot attribute \
+                 frames on any connection that already existed when it started"
+            );
+        });
+    }
 
     /// The ping is the one pushed frame that belongs to a single connection, so
     /// its line has to carry the conn_id that broadcast lines don't.

--- a/packages/mbrc-core/src/server/registry.rs
+++ b/packages/mbrc-core/src/server/registry.rs
@@ -52,16 +52,38 @@ pub enum IpAdmit {
 }
 
 /// What the registry can say about itself for a diagnostics report.
+///
+/// The counts here deliberately measure different populations, and the field
+/// names say which: `handshaked` includes loopback and excludes sockets that
+/// never negotiated, while `slots_by_ip` is the opposite on both counts. They
+/// were previously named as though they were two views of one number, which held
+/// up only because no capture had yet been taken with a loopback client
+/// connected.
 pub struct RegistryStats {
-    /// Handshaked connections currently held.
-    pub total: usize,
+    /// Handshaked connections currently held, loopback included.
+    pub handshaked: usize,
     /// How many of those are broadcast subscribers.
     pub subscribers: usize,
-    /// Reserved per-IP slots (includes sockets that never handshaked), busiest
-    /// first.
-    pub by_ip: Vec<(String, usize)>,
-    /// How long the most neglected connection has been silent.
-    pub oldest_idle_secs: u64,
+    /// Sockets holding a per-IP slot that have not completed a handshake. They
+    /// count against the cap like any other, so they belong in a report about
+    /// the cap.
+    pub unhandshaked: usize,
+    /// Reserved per-IP slots, busiest first. Loopback is exempt from the cap and
+    /// so never appears here, and un-handshaked sockets do.
+    pub slots_by_ip: Vec<(String, usize)>,
+    /// How long the most neglected *non-subscriber* has been silent. This is the
+    /// actionable one: aux sockets are what the reaper and the per-IP eviction
+    /// act on, so a large value means abandoned sockets are piling up.
+    pub oldest_aux_idle_secs: u64,
+    /// How long the quietest subscriber has been silent inbound.
+    ///
+    /// **Not a liveness signal.** iOS never answers a ping (zero pongs against
+    /// 105 pings in a 30-minute session on 2026-08-30), so this climbs without
+    /// bound on a perfectly healthy event socket and a large value here is
+    /// normal. A subscriber's health is the ping *send* succeeding plus TCP
+    /// keepalive, not this. Reported apart from the aux figure precisely so it
+    /// stops making a working connection look stale.
+    pub subscriber_idle_secs: u64,
     pub evicted_total: u64,
     pub rejected_per_ip_total: u64,
 }
@@ -325,23 +347,32 @@ impl ConnectionRegistry {
     pub fn stats(&self) -> RegistryStats {
         let now = self.now_ms();
         let inner = self.lock();
-        let mut by_ip: Vec<(String, usize)> = inner
+        let mut slots_by_ip: Vec<(String, usize)> = inner
             .by_ip
             .iter()
             .map(|(ip, count)| (ip.to_string(), *count))
             .collect();
         // Busiest first: the runaway client is the one worth seeing.
-        by_ip.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        slots_by_ip.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+        let idle_secs = |m: &ConnMeta| now.saturating_sub(m.last_active_ms) / 1000;
+        // Split the idle figures by role. Lumping them together let a subscriber
+        // - silent by design, since iOS never pongs - stand in as "the oldest
+        // idle connection" and make a healthy plugin look stalled.
+        let (subs, aux): (Vec<&ConnMeta>, Vec<&ConnMeta>) =
+            inner.conns.values().partition(|m| m.is_main);
+        // Slots are only reserved for non-loopback peers, so the handshaked
+        // connections that can account for one are the non-loopback ones.
+        let slots_reserved: usize = inner.by_ip.values().sum();
+        let handshaked_remote = inner.conns.values().filter(|m| !m.ip.is_loopback()).count();
+
         RegistryStats {
-            total: inner.conns.len(),
-            subscribers: inner.conns.values().filter(|m| m.is_main).count(),
-            by_ip,
-            oldest_idle_secs: inner
-                .conns
-                .values()
-                .map(|m| now.saturating_sub(m.last_active_ms) / 1000)
-                .max()
-                .unwrap_or(0),
+            handshaked: inner.conns.len(),
+            subscribers: subs.len(),
+            unhandshaked: slots_reserved.saturating_sub(handshaked_remote),
+            slots_by_ip,
+            oldest_aux_idle_secs: aux.iter().copied().map(idle_secs).max().unwrap_or(0),
+            subscriber_idle_secs: subs.iter().copied().map(idle_secs).max().unwrap_or(0),
             evicted_total: self.evicted_total.load(Ordering::Relaxed),
             rejected_per_ip_total: self.rejected_per_ip_total.load(Ordering::Relaxed),
         }
@@ -515,14 +546,73 @@ mod tests {
         r.touch(3);
 
         let stats = r.stats();
-        assert_eq!(stats.total, 3);
+        assert_eq!(stats.handshaked, 3);
         assert_eq!(stats.subscribers, 1);
+        assert_eq!(stats.unhandshaked, 0);
         assert_eq!(
-            stats.by_ip[0],
+            stats.slots_by_ip[0],
             ("192.168.1.5".to_string(), 2),
             "busiest first"
         );
-        assert_eq!(stats.oldest_idle_secs, 30);
+        assert_eq!(stats.oldest_aux_idle_secs, 30);
+    }
+
+    /// iOS never answers a ping, so a subscriber's inbound activity never
+    /// advances. Counting it as "the oldest idle connection" made a healthy
+    /// plugin look stalled - a live capture reported 644s while everything was
+    /// working normally.
+    #[test]
+    fn a_silent_subscriber_does_not_masquerade_as_a_stale_connection() {
+        let r = ConnectionRegistry::new(20, 40);
+        let peer = ip("192.168.1.5");
+        r.admit_ip(peer);
+        r.admit_ip(peer);
+        r.register(1, peer, None, true, false, notify()); // subscriber, never speaks
+        r.register(2, peer, None, false, false, notify());
+        r.advance(600_000);
+        r.touch(2); // the aux socket is active
+
+        let stats = r.stats();
+        assert_eq!(stats.oldest_aux_idle_secs, 0, "the aux socket just spoke");
+        assert_eq!(
+            stats.subscriber_idle_secs, 600,
+            "the subscriber's silence is still reported, but on its own field"
+        );
+    }
+
+    /// Loopback is exempt from the cap, so it reserves no slot while still being
+    /// a handshaked connection. The two counts measure different populations and
+    /// `unhandshaked` must not underflow between them.
+    #[test]
+    fn loopback_counts_as_handshaked_but_reserves_no_slot() {
+        let r = ConnectionRegistry::new(20, 40);
+        let lo = ip("127.0.0.1");
+        r.admit_ip(lo);
+        r.admit_ip(lo);
+        r.register(1, lo, None, false, true, notify());
+        r.register(2, lo, None, false, true, notify());
+
+        let stats = r.stats();
+        assert_eq!(stats.handshaked, 2);
+        assert!(stats.slots_by_ip.is_empty(), "loopback is never capped");
+        assert_eq!(stats.unhandshaked, 0, "must not underflow");
+    }
+
+    /// A socket holding a slot but never negotiating still counts against the
+    /// cap, so a report about the cap has to show it.
+    #[test]
+    fn stats_count_slots_held_by_sockets_that_never_handshaked() {
+        let r = ConnectionRegistry::new(20, 40);
+        let peer = ip("192.168.1.5");
+        r.admit_ip(peer); // handshakes below
+        r.admit_ip(peer); // never handshakes
+        r.admit_ip(peer); // never handshakes
+        r.register(1, peer, None, false, false, notify());
+
+        let stats = r.stats();
+        assert_eq!(stats.handshaked, 1);
+        assert_eq!(stats.unhandshaked, 2);
+        assert_eq!(stats.slots_by_ip[0].1, 3);
     }
 
     #[test]


### PR DESCRIPTION
Two defects in what a diagnostics bundle can *tell* you, both found while validating #194. The plugin behaves correctly in each case; the capture just cannot describe what it did. Diagnosing the lockout needed `netstat` and the absence of log lines, neither of which a reporter can send — this closes most of that gap.

## 1. Connections predating a capture lost their `conn_id`

A span records whether it is enabled **when it is constructed** and never re-evaluates it; the reload layer rebuilds interest for future callsites but cannot revive a `Span` already born as `Span::none()`. A capture raises the level after the fact, so the `debug_span!` at `connection.rs:68` was inert for every connection that already existed.

Measured in the 2026-08-30 20:21 capture:

| connection | created | level raised | lines carrying `conn{conn_id}` |
|---|---|---|---|
| conn 0 (the broadcast subscriber) | ~20:20:53 | 20:21:13 | **0** across 16 minutes |
| conn 42 (its replacement) | 20:37:16 | already raised | 12 |

Exactly backwards: the long-lived event socket is the one a push-path investigation is about. An earlier capture left 119 of 185 inbound frames unattributed the same way.

`info_span!` fixes it. INFO is the floor of every filter the plugin installs, so the span is always live:

| source | directive |
|---|---|
| `logging::init` release / debug fallback | `info` / `info,mbrc_core=debug,mbrc=debug` |
| `capture.rs` + `NativeBridge.SetLogLevel`, all three levels | all enable `mbrc_core` at INFO or lower |

The span emits nothing itself, so its level only decides whether it exists: one span per connection, nothing per frame. Side benefit — the per-client cap WARN promoted in #194 now carries `conn_id` too. This is the only span in the core.

## 2. The connection summary called a healthy plugin stalled

`oldest_idle_secs` took the max across **all** connections including subscribers. iOS never answers a ping (**0 pongs against 105** in a 30-minute session), so a subscriber's inbound activity never advances after its handshake and the field climbs without bound on a working socket. The capture reported `644` while nothing was wrong.

Split into `oldest_aux_idle_secs` — the actionable one, since aux sockets are what the reaper and eviction act on — and `subscriber_idle_secs`, documented as explicitly **not** a liveness signal.

Specifying that turned up two neighbours with the same flavour of problem:

- `total` counted handshaked connections **including** loopback
- `by_ip` counted reserved slots **excluding** loopback and **including** sockets that never handshaked

They read as two views of one number and are not. They agreed in the capture (12 and 12) only because no loopback client was connected, and diverge the moment the `mbrc monitor` soak runs. Renamed to `handshaked` / `slots_by_ip`, plus a new `unhandshaked`, since a socket holding a slot without negotiating counts against the cap like any other.

```json
"connections": {
  "handshaked": 12, "subscribers": 1, "unhandshaked": 0,
  "slots_by_ip": [{"ip": "192.168.188.20", "count": 12}],
  "oldest_aux_idle_secs": 41, "subscriber_idle_secs": 644,
  "evicted_total": 0, "rejected_per_ip_total": 0
}
```

These names shipped in `7ba1a3e` but are unreleased, so nothing depends on them yet.

## Verification

4 new unit tests (231 lib total), full suite green, `fmt` and `clippy -D warnings` clean.

The span test is a real guard rather than a restatement of the code: **verified failing on `debug_span!` and passing on `info_span!`**, by temporarily reverting the fix.

The stats tests cover a silent subscriber not skewing the aux figure, loopback counting as handshaked while reserving no slot (with `unhandshaked` not underflowing), and slots held by sockets that never negotiated.

Live check folds into the next capture rather than needing its own run: connect a client **before** starting a capture, then confirm its frames carry `conn{conn_id=N}`. Under the current build they carry nothing, so it is a clean before/after.

## Context

Preceded by the one-hour `mbrc monitor` soak on `main`: 3589 sweeps at concurrency 4, `invariant_fail 0`, `req_err 0`, `reconnects 0`, `sig_drift 0`, one persistence signature throughout, latency p50 3890ms / p99 6156ms with no upward drift.
