### PR TITLE
chore(rust): forbid unsafe where it is absent, ban bare unwrap, test on i686, and move to edition 2024

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,13 @@ jobs:
           rustup target add i686-pc-windows-msvc
           cargo build -p mbrc-core -p mbrc-helper --target i686-pc-windows-msvc --profile plugin --locked
 
+      # Building 32-bit catches what fails to compile there; running the suite
+      # catches what compiles and then behaves differently, which is where the
+      # redb store, the paging index and pointer-width arithmetic live.
+      - name: test on i686 (the ship target)
+        if: matrix.os == 'windows-latest'
+        run: cargo test -p mbrc-core -p mbrc-wire --target i686-pc-windows-msvc --locked
+
   coverage:
     name: coverage
     # Windows: mbrc-core is the Windows plugin cdylib, and this matches where the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["tools/api-debugger/src-tauri"]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 # The floor every member is built against, and the one rustc the toolchain file
 # pins. Declaring it is what makes cargo name the crate that wants a newer
 # compiler, rather than failing inside its source; with resolver 3 cargo picks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,11 @@ cognitive_complexity = "warn"
 # The backstop for what the metric above forgives. 100 sits just above the
 # tree's p99, so it catches outliers rather than arguing with ordinary work.
 too_many_lines = "warn"
+# A panic in the core unwinds into MusicBee's own thread. `expect` stays
+# available because its message is the argument for why the case cannot
+# happen; a bare `unwrap` makes that argument without stating it. Tests are
+# exempt via clippy.toml.
+unwrap_used = "warn"
 
 # Exact-version pins match the api-debugger's supply-chain hardening so both
 # workspaces resolve the shared crates against identical dependency versions.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# Tests may unwrap: a panic there is the failure report, and threading a
+# Result through every assertion buys nothing. Production code may not, which
+# is what `clippy::unwrap_used` in the workspace lints enforces.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/packages/mbrc-buildinfo/src/lib.rs
+++ b/packages/mbrc-buildinfo/src/lib.rs
@@ -11,6 +11,8 @@
 //! Crate `version` fields in this workspace all stay at 0.1.0. They are
 //! workspace-internal numbers and nothing publishes them.
 
+#![forbid(unsafe_code)]
+
 use std::path::{Path, PathBuf};
 
 /// The props file every version comes from.

--- a/packages/mbrc-capture/src/lib.rs
+++ b/packages/mbrc-capture/src/lib.rs
@@ -22,14 +22,14 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
-use time::format_description::well_known::Rfc3339;
+use serde_json::{Value, json};
 use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 pub mod schema;
 pub mod trim;
-pub use schema::{endpoint_schemas, endpoint_values, EndpointSchemas, EndpointValues, FieldMap};
-pub use trim::{trim_capture, TrimOutput, PLACEHOLDER_LYRICS, PLACEHOLDER_PNG_B64};
+pub use schema::{EndpointSchemas, EndpointValues, FieldMap, endpoint_schemas, endpoint_values};
+pub use trim::{PLACEHOLDER_LYRICS, PLACEHOLDER_PNG_B64, TrimOutput, trim_capture};
 
 /// Capture format version, written into the file header.
 pub const CAPTURE_FORMAT: &str = "mbrc-capture/2";

--- a/packages/mbrc-capture/src/lib.rs
+++ b/packages/mbrc-capture/src/lib.rs
@@ -19,6 +19,8 @@
 //! producer (the api-debugger proxy), the CLI (`trim`/`inspect`), and the
 //! replay harness, so a producer and a consumer can never drift.
 
+#![forbid(unsafe_code)]
+
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use time::format_description::well_known::Rfc3339;

--- a/packages/mbrc-capture/src/schema.rs
+++ b/packages/mbrc-capture/src/schema.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
 
-use crate::{parse_line, Record};
+use crate::{Record, parse_line};
 
 /// Field path (dotted, `[]` for array element) -> JSON type. When a path shows
 /// more than one type across frames the types are unioned as `"a|b"`.

--- a/packages/mbrc-capture/src/trim.rs
+++ b/packages/mbrc-capture/src/trim.rs
@@ -169,11 +169,13 @@ pub fn trim_capture(contents: &str) -> TrimOutput {
     let mut order: Vec<u32> = Vec::new();
     let mut by_conn: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
     for (i, fr) in frames.iter().enumerate() {
-        by_conn.entry(fr.conn_id).or_insert_with(|| {
-            order.push(fr.conn_id);
-            Vec::new()
-        });
-        by_conn.get_mut(&fr.conn_id).unwrap().push(i);
+        by_conn
+            .entry(fr.conn_id)
+            .or_insert_with(|| {
+                order.push(fr.conn_id);
+                Vec::new()
+            })
+            .push(i);
     }
 
     // Bucket connections by (platform, protocol), preserving first-seen order.
@@ -297,7 +299,7 @@ fn bucket_name(platform: Option<&str>, protocol: Option<i64>) -> String {
         None => "apidebugger",
     };
     match protocol {
-        Some(2) | Some(3) => format!("legacy-v{}", protocol.unwrap()),
+        Some(v @ (2 | 3)) => format!("legacy-v{v}"),
         Some(v) => format!("legacy-v{v}-{plat}"),
         None => format!("legacy-unknown-{plat}"),
     }

--- a/packages/mbrc-capture/src/trim.rs
+++ b/packages/mbrc-capture/src/trim.rs
@@ -23,7 +23,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use serde_json::{Map, Value};
 
-use crate::{parse_line, Record};
+use crate::{Record, parse_line};
 
 /// 1x1 transparent PNG, base64. Small enough to be a non-event in fixtures but
 /// still a valid decodable image for anyone debugging by hand.
@@ -262,22 +262,24 @@ fn classify(
     if hs.client_type.is_none() {
         for &i in idxs {
             let fr = &frames[i];
-            if fr.context() == Some("player") && fr.dir() == "c2s" {
-                if let Some(Value::String(s)) = fr.frame_data() {
-                    hs.client_type = Some(s.clone());
-                    break;
-                }
+            if fr.context() == Some("player")
+                && fr.dir() == "c2s"
+                && let Some(Value::String(s)) = fr.frame_data()
+            {
+                hs.client_type = Some(s.clone());
+                break;
             }
         }
     }
     if hs.protocol_version.is_none() {
         for &i in idxs {
             let fr = &frames[i];
-            if fr.context() == Some("protocol") && fr.dir() == "c2s" {
-                if let Some(data) = fr.frame_data() {
-                    hs.protocol_version = extract_protocol_version(data);
-                    break;
-                }
+            if fr.context() == Some("protocol")
+                && fr.dir() == "c2s"
+                && let Some(data) = fr.frame_data()
+            {
+                hs.protocol_version = extract_protocol_version(data);
+                break;
             }
         }
     }
@@ -335,12 +337,10 @@ fn rewrite_placeholders(rec: &Value, scrub: &mut Scrubber) -> Value {
 
     // A rewritten frame's `raw` (exact wire bytes) no longer matches the parsed
     // frame, so re-derive it. preserve_order keeps the key order faithful.
-    if changed {
-        if let Some(frame) = out.get("frame") {
-            let raw = serde_json::to_string(frame).unwrap_or_default();
-            if let Some(obj) = out.as_object_mut() {
-                obj.insert("raw".into(), Value::from(raw));
-            }
+    if changed && let Some(frame) = out.get("frame") {
+        let raw = serde_json::to_string(frame).unwrap_or_default();
+        if let Some(obj) = out.as_object_mut() {
+            obj.insert("raw".into(), Value::from(raw));
         }
     }
     out
@@ -510,10 +510,10 @@ fn rewrite_long_string_field(
     replacement: &str,
     threshold: usize,
 ) {
-    if let Some(Value::String(s)) = obj.get_mut(field) {
-        if s.len() > threshold {
-            *s = replacement.to_string();
-        }
+    if let Some(Value::String(s)) = obj.get_mut(field)
+        && s.len() > threshold
+    {
+        *s = replacement.to_string();
     }
 }
 
@@ -786,10 +786,12 @@ mod tests {
         // Same original path -> same token (referential consistency).
         let arr = q["frame"]["data"]["data"].as_array().unwrap();
         assert_eq!(arr[0], arr[1]);
-        assert!(arr[0]
-            .as_str()
-            .unwrap()
-            .starts_with("\\\\host\\media\\item-"));
+        assert!(
+            arr[0]
+                .as_str()
+                .unwrap()
+                .starts_with("\\\\host\\media\\item-")
+        );
     }
 
     #[test]

--- a/packages/mbrc-core/build.rs
+++ b/packages/mbrc-core/build.rs
@@ -124,10 +124,10 @@ fn generate_enums() {
 
     let mut body = String::new();
     for item in &file.items {
-        if let Item::Enum(e) = item {
-            if is_repr_i32(&e.attrs) {
-                emit_enum(&mut body, e);
-            }
+        if let Item::Enum(e) = item
+            && is_repr_i32(&e.attrs)
+        {
+            emit_enum(&mut body, e);
         }
     }
 
@@ -285,10 +285,10 @@ fn map_type(ty: &Type, enums: &HashSet<String>) -> String {
 }
 
 fn first_type_arg(seg: &syn::PathSegment, enums: &HashSet<String>) -> String {
-    if let PathArguments::AngleBracketed(ab) = &seg.arguments {
-        if let Some(GenericArgument::Type(t)) = ab.args.first() {
-            return map_type(t, enums);
-        }
+    if let PathArguments::AngleBracketed(ab) = &seg.arguments
+        && let Some(GenericArgument::Type(t)) = ab.args.first()
+    {
+        return map_type(t, enums);
     }
     "object".to_string()
 }
@@ -423,10 +423,10 @@ fn escape_ident(name: &str) -> String {
 fn write_if_changed(path: &Path, content: &str) {
     // Normalize any mix to LF first, then to CRLF, so we never emit `\r\r\n`.
     let crlf = content.replace("\r\n", "\n").replace('\n', "\r\n");
-    if let Ok(existing) = std::fs::read_to_string(path) {
-        if existing == crlf {
-            return;
-        }
+    if let Ok(existing) = std::fs::read_to_string(path)
+        && existing == crlf
+    {
+        return;
     }
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).expect("create the generated-bindings directory");

--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -273,14 +273,12 @@ impl Config {
             });
             // Migrate a pre-`log_level` file: an old `debug:true` (and no
             // `log_level` key) maps to Debug. The new file drops `debug` on save.
-            if config.log_level == LogLevel::Info {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&contents) {
-                    if v.get("log_level").is_none()
-                        && v.get("debug").and_then(serde_json::Value::as_bool) == Some(true)
-                    {
-                        config.log_level = LogLevel::Debug;
-                    }
-                }
+            if config.log_level == LogLevel::Info
+                && let Ok(v) = serde_json::from_str::<serde_json::Value>(&contents)
+                && v.get("log_level").is_none()
+                && v.get("debug").and_then(serde_json::Value::as_bool) == Some(true)
+            {
+                config.log_level = LogLevel::Debug;
             }
         } else {
             tracing::info!("no core_settings.json found; using default config");

--- a/packages/mbrc-core/src/cover/store.rs
+++ b/packages/mbrc-core/src/cover/store.rs
@@ -288,7 +288,7 @@ impl CoverStore {
                         let mut local = BuildStats::default();
                         loop {
                             // Held only to pull one item, never across the store.
-                            let item = rx.lock().unwrap().recv();
+                            let item = rx.lock().expect("cover queue mutex poisoned").recv();
                             let Ok((key, path, raw, fetch_ms)) = item else {
                                 break; // producer dropped the sender: queue drained
                             };

--- a/packages/mbrc-core/src/cover/store.rs
+++ b/packages/mbrc-core/src/cover/store.rs
@@ -20,14 +20,14 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use redb::{Durability, ReadableTable};
 
-use super::{resize_to_jpeg, sha1_hex, CACHE_SIZE};
-use crate::store::{Db, COVER_COVERS, COVER_META, LAST_CHECK};
+use super::{CACHE_SIZE, resize_to_jpeg, sha1_hex};
+use crate::store::{COVER_COVERS, COVER_META, Db, LAST_CHECK};
 
 /// One album's identity ingredients, provided by the host.
 ///

--- a/packages/mbrc-core/src/diagnostics/redact.rs
+++ b/packages/mbrc-core/src/diagnostics/redact.rs
@@ -118,10 +118,12 @@ mod tests {
         // diagnosable from the bundle.
         let out = settings(settings_json());
         assert_eq!(out["port"], 3000);
-        assert!(out["storage_path"]
-            .as_str()
-            .expect("path stays a string")
-            .contains("mb_remote"));
+        assert!(
+            out["storage_path"]
+                .as_str()
+                .expect("path stays a string")
+                .contains("mb_remote")
+        );
     }
 
     #[test]

--- a/packages/mbrc-core/src/diagnostics/report.rs
+++ b/packages/mbrc-core/src/diagnostics/report.rs
@@ -4,8 +4,8 @@
 //! Nothing here is new state - it is the values the settings panel, update flow
 //! and caches already hold, gathered so a maintainer never has to ask for them.
 
-use serde_json::{json, Value};
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::diagnostics::redact;
 use crate::ffi::dtos::CaptureEnvEntry;

--- a/packages/mbrc-core/src/discovery.rs
+++ b/packages/mbrc-core/src/discovery.rs
@@ -18,7 +18,7 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
 use tokio::sync::Notify;
@@ -135,13 +135,12 @@ fn client_address(req: &[u8]) -> Option<Ipv4Addr> {
 /// subnet match.
 fn advertise_ip(client_ip: Option<Ipv4Addr>) -> Option<Ipv4Addr> {
     let ifaces = usable_ipv4_ifaces();
-    if let Some(client) = client_ip {
-        if let Some((ip, _)) = ifaces
+    if let Some(client) = client_ip
+        && let Some((ip, _)) = ifaces
             .iter()
             .find(|(ip, mask)| same_subnet(*ip, client, *mask))
-        {
-            return Some(*ip);
-        }
+    {
+        return Some(*ip);
     }
     best_private_ipv4(&ifaces)
 }

--- a/packages/mbrc-core/src/ffi/callbacks.rs
+++ b/packages/mbrc-core/src/ffi/callbacks.rs
@@ -7,8 +7,8 @@
 //! The typed, per-`QueryType`/`CommandType` wrappers live in the `Providers`
 //! layer (`crate::providers`) so this stays a thin, generic boundary.
 
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use crate::ffi::types::{CommandType, HostEventType, MbrcCallbacks, QueryType};
 

--- a/packages/mbrc-core/src/legacy.rs
+++ b/packages/mbrc-core/src/legacy.rs
@@ -67,19 +67,19 @@ pub fn sweep(storage_path: &str, plugins_dir: Option<&Path>) {
         }
     }
 
-    if migrated_settings_are_present(storage) {
-        if let Some(size) = remove_file(storage, "settings.xml") {
-            removed += 1;
-            freed += size;
-        }
+    if migrated_settings_are_present(storage)
+        && let Some(size) = remove_file(storage, "settings.xml")
+    {
+        removed += 1;
+        freed += size;
     }
 
     let cache = storage.join("cache");
-    if is_real_directory(&cache) {
-        if let Some(size) = remove_file(&cache, MIGRATED_COVER_STATE) {
-            removed += 1;
-            freed += size;
-        }
+    if is_real_directory(&cache)
+        && let Some(size) = remove_file(&cache, MIGRATED_COVER_STATE)
+    {
+        removed += 1;
+        freed += size;
     }
 
     if let Some(plugins) = plugins_dir {
@@ -188,7 +188,7 @@ fn is_multiply_linked(path: &Path, _meta: &std::fs::Metadata) -> bool {
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Foundation::HANDLE;
     use windows_sys::Win32::Storage::FileSystem::{
-        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
     };
 
     let Ok(file) = std::fs::File::open(path) else {

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -22,13 +22,13 @@ pub mod store;
 pub mod updates;
 pub mod wire;
 
-use std::ffi::{c_char, c_int, CStr, CString};
+use std::ffi::{CStr, CString, c_char, c_int};
 use std::sync::Arc;
 
 use crate::ffi::callbacks::SafeCallbacks;
 use crate::ffi::types::{
-    HostCommandType, HostQueryType, MbrcCallbacks, MbrcResult, NotificationType, UpdateLaunch,
-    MBRC_ABI_VERSION,
+    HostCommandType, HostQueryType, MBRC_ABI_VERSION, MbrcCallbacks, MbrcResult, NotificationType,
+    UpdateLaunch,
 };
 use crate::providers::{FfiProviders, Providers};
 
@@ -70,7 +70,7 @@ fn ffi_guard(export: &'static str, body: impl FnOnce() -> c_int) -> c_int {
 ///
 /// # Safety
 /// `storage_path` must be a valid, NUL-terminated C string (or null).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_initialize(
     abi_version: c_int,
     callbacks: MbrcCallbacks,
@@ -115,13 +115,13 @@ pub unsafe extern "C" fn mbrc_initialize(
 }
 
 /// Stops networking and releases the core; a later `mbrc_initialize` may re-init.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn mbrc_shutdown() -> c_int {
     ffi_guard("mbrc_shutdown", || state::shutdown() as c_int)
 }
 
 /// Starts the TCP command server + UDP discovery responder.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn mbrc_start_networking() -> c_int {
     ffi_guard("mbrc_start_networking", || {
         state::start_networking() as c_int
@@ -129,7 +129,7 @@ pub extern "C" fn mbrc_start_networking() -> c_int {
 }
 
 /// Gracefully stop networking (leaves the core initialized).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn mbrc_stop_networking() -> c_int {
     ffi_guard("mbrc_stop_networking", || state::stop_networking() as c_int)
 }
@@ -141,7 +141,7 @@ pub extern "C" fn mbrc_stop_networking() -> c_int {
 /// hand those milliseconds over as a head start and find the wait in
 /// `mbrc_stop_networking` already over. Cleared by the next
 /// `mbrc_start_networking`, so a port change is unaffected. Idempotent.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn mbrc_begin_stopping() -> c_int {
     ffi_guard("mbrc_begin_stopping", || state::begin_stopping() as c_int)
 }
@@ -155,7 +155,7 @@ pub extern "C" fn mbrc_begin_stopping() -> c_int {
 ///
 /// # Safety
 /// `out_len` must be null or point to a writable `u32`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_read_settings(out_len: *mut u32) -> *mut u8 {
     if !out_len.is_null() {
         // SAFETY: `out_len` is null-checked above and the contract says it points to a
@@ -188,7 +188,7 @@ pub unsafe extern "C" fn mbrc_read_settings(out_len: *mut u32) -> *mut u8 {
 ///
 /// # Safety
 /// `buf` must be null or point to `len` readable bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_write_settings(buf: *const u8, len: u32) -> c_int {
     ffi_guard("mbrc_write_settings", || {
         if buf.is_null() {
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn mbrc_write_settings(buf: *const u8, len: u32) -> c_int 
 /// # Safety
 /// `params_buf` must be null or point to `params_len` readable bytes; `out_len`
 /// must be null or point to a writable `u32`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_query(
     query_type: c_int,
     params_buf: *const u8,
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn mbrc_query(
 ///
 /// # Safety
 /// `params_buf` must be null or point to `params_len` readable bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_command(
     command_type: c_int,
     params_buf: *const u8,
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn mbrc_command(
 ///
 /// # Safety
 /// `ptr`/`len` must come from `mbrc_read_settings` and be freed exactly once.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_free_bytes(ptr: *mut u8, len: u32) {
     if ptr.is_null() {
         return;
@@ -308,7 +308,7 @@ pub unsafe extern "C" fn mbrc_free_bytes(ptr: *mut u8, len: u32) {
 /// Carries an optional MessagePack payload (`params_buf`/`params_len`, e.g. the
 /// added/changed file URL) so the broadcast fan-out can build the right
 /// broadcast. Empty payload = null/0.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn mbrc_handle_notification(
     notification_type: c_int,
     _params_buf: *const u8,
@@ -328,7 +328,7 @@ pub extern "C" fn mbrc_handle_notification(
 ///
 /// # Safety
 /// `target` and `message` must be null or valid NUL-terminated C strings.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_log(
     level: c_int,
     target: *const c_char,
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn mbrc_log(
 ///
 /// # Safety
 /// `directive` must be null or a valid NUL-terminated C string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_set_log_level(directive: *const c_char) -> c_int {
     ffi_guard("mbrc_set_log_level", || {
         // SAFETY: null-checked above, and the caller's contract says it is a valid
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn mbrc_set_log_level(directive: *const c_char) -> c_int {
 /// waiting for MusicBee to exit, so the caller shuts it down next. `Cancelled`
 /// leaves the staged update in place for a retry, and `NotAnUpgrade` means the
 /// bundle verified but is not newer - a refusal rather than a failure.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn mbrc_apply_staged_update() -> c_int {
     ffi_guard(
         "mbrc_apply_staged_update",
@@ -391,7 +391,7 @@ pub extern "C" fn mbrc_apply_staged_update() -> c_int {
 /// # Safety
 /// `ptr` must be null or a pointer previously returned by this core (from
 /// `CString::into_raw`); it must not be freed twice.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn mbrc_free_string(ptr: *mut c_char) {
     // Void return, so guard inline rather than via `ffi_guard`.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -417,7 +417,7 @@ mod ffi_smoke_tests {
     use crate::ffi::types::{CommandType, QueryType};
     use crate::protocol::messages::PlaybackPositionResponse;
     use crate::providers::Providers;
-    use std::alloc::{alloc, dealloc, Layout};
+    use std::alloc::{Layout, alloc, dealloc};
     use std::cell::RefCell;
     use std::collections::HashMap;
 

--- a/packages/mbrc-core/src/logging.rs
+++ b/packages/mbrc-core/src/logging.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use serde_json::Value;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{fmt, reload, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, fmt, reload};
 
 static INIT: OnceLock<()> = OnceLock::new();
 
@@ -355,17 +355,17 @@ fn redact_value(v: &mut Value, key: Option<&str>, max_array: Option<usize>) {
             }
         }
         Value::Array(items) => {
-            if let Some(max) = max_array {
-                if items.len() > max {
-                    let extra = items.len() - max;
-                    let schema = array_schema(&items[max]);
-                    items.truncate(max);
-                    for it in items.iter_mut() {
-                        redact_value(it, key, max_array);
-                    }
-                    items.push(Value::String(format!("<+{extra} more items{schema}>")));
-                    return;
+            if let Some(max) = max_array
+                && items.len() > max
+            {
+                let extra = items.len() - max;
+                let schema = array_schema(&items[max]);
+                items.truncate(max);
+                for it in items.iter_mut() {
+                    redact_value(it, key, max_array);
                 }
+                items.push(Value::String(format!("<+{extra} more items{schema}>")));
+                return;
             }
             items
                 .iter_mut()
@@ -435,11 +435,11 @@ pub mod test_support {
     use std::fmt::Debug;
     use std::sync::{Arc, Mutex};
 
-    use tracing::field::{Field, Visit};
     use tracing::Subscriber;
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::Registry;
     use tracing_subscriber::layer::{Context, Layer};
     use tracing_subscriber::prelude::*;
-    use tracing_subscriber::Registry;
 
     /// The subset of a `mbrc::wire` event that the broadcast/ping tests assert on.
     #[derive(Debug, Default, Clone)]

--- a/packages/mbrc-core/src/metadata_cache.rs
+++ b/packages/mbrc-core/src/metadata_cache.rs
@@ -18,12 +18,12 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use redb::{Durability, ReadableTableMetadata};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use crate::protocol::messages::Track;
 use crate::store::{
-    Db, LIBRARY_FINGERPRINT, META, METADATA_CACHE, TRACKS_SYNCED_AT, TRACK_PATHS, TRACK_TAGS,
+    Db, LIBRARY_FINGERPRINT, META, METADATA_CACHE, TRACK_PATHS, TRACK_TAGS, TRACKS_SYNCED_AT,
 };
 
 pub struct MetadataCache {

--- a/packages/mbrc-core/src/protocol/version.rs
+++ b/packages/mbrc-core/src/protocol/version.rs
@@ -4,7 +4,7 @@
 //! variant here plus a `wire` formatter is the entire change - handlers select
 //! their formatter via `ProtocolVersion::formatter()` and never name a version.
 
-use crate::wire::{WireCodec, V4_CODEC};
+use crate::wire::{V4_CODEC, WireCodec};
 
 /// A protocol version the core can format wire frames for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/packages/mbrc-core/src/server/broadcaster.rs
+++ b/packages/mbrc-core/src/server/broadcaster.rs
@@ -5,8 +5,8 @@
 //! registered client.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -117,7 +117,7 @@ impl Broadcaster {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::logging::test_support::{capture_wire_lines, WireLine};
+    use crate::logging::test_support::{WireLine, capture_wire_lines};
     use tokio::sync::mpsc;
 
     #[test]

--- a/packages/mbrc-core/src/server/commands/library.rs
+++ b/packages/mbrc-core/src/server/commands/library.rs
@@ -6,11 +6,11 @@
 
 use std::collections::HashMap;
 
-use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
 
-use super::{as_bool_lenient, as_set_string, pagination, reply_dto, Ctx, HandlerResult};
+use super::{Ctx, HandlerResult, as_bool_lenient, as_set_string, pagination, reply_dto};
 use crate::cover::{cover_identifier, from_base64, store::CoverStore};
 use crate::metadata_cache::MetadataCache;
 use crate::protocol::messages::{AlbumCover, AlbumCoverItem, Page, Track};
@@ -97,16 +97,16 @@ fn serve_tracks_from_store(
         .map(|(path, _)| path.clone())
         .collect();
 
-    if !misses.is_empty() {
-        if let Ok(fetched) = p.tracks_for_paths(misses) {
-            cache.put_track_tags(&fetched);
-            // Fill the holes from the batch we just fetched (no second DB read).
-            let mut by_path: HashMap<&str, &Track> =
-                fetched.iter().map(|t| (t.src.as_str(), t)).collect();
-            for (slot, path) in resolved.iter_mut().zip(&paths) {
-                if slot.is_none() {
-                    *slot = by_path.remove(path.as_str()).cloned();
-                }
+    if !misses.is_empty()
+        && let Ok(fetched) = p.tracks_for_paths(misses)
+    {
+        cache.put_track_tags(&fetched);
+        // Fill the holes from the batch we just fetched (no second DB read).
+        let mut by_path: HashMap<&str, &Track> =
+            fetched.iter().map(|t| (t.src.as_str(), t)).collect();
+        for (slot, path) in resolved.iter_mut().zip(&paths) {
+            if slot.is_none() {
+                *slot = by_path.remove(path.as_str()).cloned();
             }
         }
     }
@@ -308,10 +308,10 @@ where
     T: Serialize + DeserializeOwned + Default,
     F: FnOnce() -> Result<Page<T>, String>,
 {
-    if let Some(cache) = ctx.metadata_cache {
-        if let Some(cached) = cache.get::<Page<T>>(key) {
-            return Ok(slice_page(cached, offset, limit));
-        }
+    if let Some(cache) = ctx.metadata_cache
+        && let Some(cached) = cache.get::<Page<T>>(key)
+    {
+        return Ok(slice_page(cached, offset, limit));
     }
     let full = fetch_full()?;
     if let Some(cache) = ctx.metadata_cache {
@@ -346,10 +346,10 @@ where
     T: Serialize + DeserializeOwned,
     F: FnOnce() -> Result<Vec<T>, String>,
 {
-    if let Some(cache) = ctx.metadata_cache {
-        if let Some(list) = cache.get::<Vec<T>>(key) {
-            return Ok(list);
-        }
+    if let Some(cache) = ctx.metadata_cache
+        && let Some(list) = cache.get::<Vec<T>>(key)
+    {
+        return Ok(list);
     }
     let list = fetch()?;
     if let Some(cache) = ctx.metadata_cache {

--- a/packages/mbrc-core/src/server/commands/nowplaying_list.rs
+++ b/packages/mbrc-core/src/server/commands/nowplaying_list.rs
@@ -2,9 +2,9 @@
 //! search, and queue. Mutations echo a small success object; the client
 //! typically re-requests the list afterward.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::{as_int_lenient, as_set_string, pagination, Ctx, HandlerResult, Platform};
+use super::{Ctx, HandlerResult, Platform, as_int_lenient, as_set_string, pagination};
 use crate::providers::Providers;
 
 /// Reads an index from either a bare int (or stringified int) or an
@@ -161,9 +161,10 @@ mod tests {
         let track = &out[0].1["data"][0];
         assert_eq!(track["album"], json!("Album"));
         assert_eq!(track["album_artist"], json!("AlbumArtist"));
-        assert!(m
-            .recorded()
-            .contains(&"now_playing_list_ordered".to_string()));
+        assert!(
+            m.recorded()
+                .contains(&"now_playing_list_ordered".to_string())
+        );
 
         // iOS index is used as-is.
         play(&json!(3), &ctx).unwrap();

--- a/packages/mbrc-core/src/server/commands/player.rs
+++ b/packages/mbrc-core/src/server/commands/player.rs
@@ -5,9 +5,9 @@
 //! the V4 wire spelling (stringified volume, enum spellings) is applied by
 //! `ctx.wire()` (the `wire::v4` formatter).
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::{as_bool_lenient, as_int_lenient, Ctx, HandlerResult};
+use super::{Ctx, HandlerResult, as_bool_lenient, as_int_lenient};
 use crate::protocol::messages::{RepeatMode, ShuffleMode};
 
 /// One reply on the same context, echoing `true` for a fire-and-forget action.
@@ -197,10 +197,10 @@ pub fn output(_data: &Value, ctx: &Ctx) -> HandlerResult {
 /// # Errors
 /// The provider call failed.
 pub fn output_switch(data: &Value, ctx: &Ctx) -> HandlerResult {
-    if let Some(device) = data.as_str() {
-        if !device.is_empty() {
-            ctx.providers.switch_output(device)?;
-        }
+    if let Some(device) = data.as_str()
+        && !device.is_empty()
+    {
+        ctx.providers.switch_output(device)?;
     }
     let devices = ctx.providers.output_devices()?;
     Ok(vec![(
@@ -296,9 +296,10 @@ mod tests {
         // `playeroutputswitch` with a name switches; empty name is ignored.
         let m = mock();
         output_switch(&json!("Headphones"), &ctx(&m)).unwrap();
-        assert!(m
-            .recorded()
-            .contains(&"switch_output(Headphones)".to_string()));
+        assert!(
+            m.recorded()
+                .contains(&"switch_output(Headphones)".to_string())
+        );
 
         let m = mock();
         output_switch(&json!(""), &ctx(&m)).unwrap();

--- a/packages/mbrc-core/src/server/commands/playlists.rs
+++ b/packages/mbrc-core/src/server/commands/playlists.rs
@@ -1,8 +1,8 @@
 //! Playlist handlers: list (paginated) and play by URL.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::{pagination, reply_dto, HandlerResult};
+use super::{HandlerResult, pagination, reply_dto};
 use crate::providers::Providers;
 
 pub fn list(data: &Value, p: &dyn Providers) -> HandlerResult {
@@ -46,8 +46,9 @@ mod tests {
             play(&json!("playlist://x"), &m).unwrap()[0],
             ("playlistplay".into(), json!(true))
         );
-        assert!(m
-            .recorded()
-            .contains(&"play_playlist(playlist://x)".to_string()));
+        assert!(
+            m.recorded()
+                .contains(&"play_playlist(playlist://x)".to_string())
+        );
     }
 }

--- a/packages/mbrc-core/src/server/commands/system.rs
+++ b/packages/mbrc-core/src/server/commands/system.rs
@@ -4,9 +4,9 @@
 //! The handshake contexts themselves (player, protocol, ping, pong,
 //! verifyconnection) are handled in `session`.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::{reply_dto, Ctx, HandlerResult};
+use super::{Ctx, HandlerResult, reply_dto};
 use crate::providers::Providers;
 
 /// The version advertised to V4 legacy clients.

--- a/packages/mbrc-core/src/server/commands/track.rs
+++ b/packages/mbrc-core/src/server/commands/track.rs
@@ -4,9 +4,9 @@
 //! The response DTOs already match the wire shapes, so most handlers just
 //! serialize the provider result.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::{as_int_lenient, as_set_string, Ctx, HandlerResult};
+use super::{Ctx, HandlerResult, as_int_lenient, as_set_string};
 use crate::protocol::messages::LastfmStatus;
 use crate::providers::Providers;
 

--- a/packages/mbrc-core/src/server/connection.rs
+++ b/packages/mbrc-core/src/server/connection.rs
@@ -11,12 +11,12 @@ use std::time::Duration;
 
 use socket2::{SockRef, TcpKeepalive};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::OwnedWriteHalf;
 use tokio::net::TcpStream;
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::net::tcp::OwnedWriteHalf;
 use tokio::sync::Notify;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use mbrc_wire::{frame_line, FrameAccumulator};
+use mbrc_wire::{FrameAccumulator, frame_line};
 
 use crate::server::registry::{Admit, Role};
 use crate::server::session::Session;

--- a/packages/mbrc-core/src/server/monitor.rs
+++ b/packages/mbrc-core/src/server/monitor.rs
@@ -77,12 +77,12 @@ fn poll(
     let wire = ProtocolVersion::V4.codec();
 
     // Position is throttled to every 20s (emit_position); only query it then.
-    if emit_position && state.play_state == PlayState::Playing {
-        if let Ok(position) = providers.playback_position() {
-            if let Ok(value) = serde_json::to_value(&position) {
-                frames.push(frame("nowplayingposition", value));
-            }
-        }
+    if emit_position
+        && state.play_state == PlayState::Playing
+        && let Ok(position) = providers.playback_position()
+        && let Ok(value) = serde_json::to_value(&position)
+    {
+        frames.push(frame("nowplayingposition", value));
     }
     if seed_or_changed(&mut cached.shuffle, state.shuffle) {
         frames.push(frame("playershuffle", wire.shuffle(state.shuffle)));

--- a/packages/mbrc-core/src/server/notifications.rs
+++ b/packages/mbrc-core/src/server/notifications.rs
@@ -12,7 +12,7 @@
 //! - LyricsReady/ArtworkReady -> lyrics/cover; ListChanged -> nowplayinglistchanged
 //! - FileAddedToLibrary -> no broadcast (caches the cover, C#-side)
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::ffi::types::NotificationType;
 use crate::nowplaying::NowPlaying;

--- a/packages/mbrc-core/src/server/registry.rs
+++ b/packages/mbrc-core/src/server/registry.rs
@@ -302,10 +302,10 @@ impl ConnectionRegistry {
 
         // Wake the superseded main's task so it closes. `notify_one` stores a
         // permit if the task isn't awaiting yet, so there is no lost-wakeup race.
-        if let Some(old) = superseded.filter(|&old| old != conn_id) {
-            if let Some(notify) = inner.shutdown.get(&old) {
-                notify.notify_one();
-            }
+        if let Some(old) = superseded.filter(|&old| old != conn_id)
+            && let Some(notify) = inner.shutdown.get(&old)
+        {
+            notify.notify_one();
         }
         Admit::Admitted
     }

--- a/packages/mbrc-core/src/server/session.rs
+++ b/packages/mbrc-core/src/server/session.rs
@@ -7,7 +7,7 @@
 //! It handles the handshake (`player`, `protocol`), keepalive and health
 //! (`ping`, `pong`, `verifyconnection`), and dispatch for every other context.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use mbrc_wire::parse_lenient;
 

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -19,7 +19,7 @@ use crate::providers::Providers;
 use crate::server::blocked::BlockedLog;
 use crate::server::broadcaster::Broadcaster;
 use crate::server::registry::ConnectionRegistry;
-use crate::server::{self, notifications, NetHandle, RebuildScope};
+use crate::server::{self, NetHandle, RebuildScope, notifications};
 use crate::store::Db;
 
 /// The initialized core: the provider boundary, config, the broadcast registry,
@@ -736,11 +736,13 @@ mod tests {
     #[test]
     fn merge_rejects_a_non_map_payload_and_bad_field_types() {
         assert!(merge_settings(Config::default(), &serde_json::json!([1, 2])).is_err());
-        assert!(merge_settings(
-            Config::default(),
-            &serde_json::json!({"port": "not a number"})
-        )
-        .is_err());
+        assert!(
+            merge_settings(
+                Config::default(),
+                &serde_json::json!({"port": "not a number"})
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -13,7 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
-use mbrc_release::{stage::STAGING_DIR, verify_bundled_file, verify_manifest, Manifest};
+use mbrc_release::{Manifest, stage::STAGING_DIR, verify_bundled_file, verify_manifest};
 
 use crate::ffi::types::UpdateLaunch;
 
@@ -301,8 +301,8 @@ pub(crate) fn plugins_dir() -> Option<PathBuf> {
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::HMODULE;
     use windows_sys::Win32::System::LibraryLoader::{
-        GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        GetModuleFileNameW, GetModuleHandleExW,
     };
 
     let mut module: HMODULE = std::ptr::null_mut();
@@ -427,9 +427,10 @@ const SETTLE: std::time::Duration = std::time::Duration::from_millis(750);
 fn spawn_in_container(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
-        CreateProcessW, DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
-        UpdateProcThreadAttribute, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST,
-        PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, STARTUPINFOEXW,
+        CreateProcessW, DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT,
+        InitializeProcThreadAttributeList, LPPROC_THREAD_ATTRIBUTE_LIST,
+        PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, PROCESS_INFORMATION, STARTUPINFOEXW,
+        UpdateProcThreadAttribute,
     };
     use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_DESKTOP_APP_BREAKAWAY_OVERRIDE;
 
@@ -574,7 +575,7 @@ unsafe fn settled_exit_code(process: windows_sys::Win32::Foundation::HANDLE) -> 
 fn spawn_elevated(exe: &Path, arguments: &[String]) -> UpdateLaunch {
     use windows_sys::Win32::Foundation::{CloseHandle, ERROR_CANCELLED};
     use windows_sys::Win32::UI::Shell::{
-        ShellExecuteExW, SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW,
+        SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW,
     };
     use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 

--- a/packages/mbrc-core/src/updates/mod.rs
+++ b/packages/mbrc-core/src/updates/mod.rs
@@ -15,8 +15,9 @@ pub mod elevate;
 pub mod service;
 
 use mbrc_release::{
+    AvailableUpdate, HttpClient, Result, StagedUpdate, UpdateState,
     check::{self, CheckOptions, CheckOutcome},
-    stage, AvailableUpdate, HttpClient, Result, StagedUpdate, UpdateState,
+    stage,
 };
 use time::OffsetDateTime;
 

--- a/packages/mbrc-core/src/updates/service.rs
+++ b/packages/mbrc-core/src/updates/service.rs
@@ -19,7 +19,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use mbrc_release::{check::CheckOutcome, AvailableUpdate, HttpClient, Result, UpdateState};
+use mbrc_release::{AvailableUpdate, HttpClient, Result, UpdateState, check::CheckOutcome};
 
 use crate::ffi::types::{HostEventType, MbrcResult};
 use crate::state::Core;
@@ -461,8 +461,8 @@ fn client(_core: &Core) -> std::result::Result<Box<dyn HttpClient>, String> {
 mod tests {
     use super::*;
     use mbrc_release::{
-        manifest::{Artifact, Artifacts},
         Channel, Manifest, UpdateError,
+        manifest::{Artifact, Artifacts},
     };
 
     fn manifest(version: &str) -> Manifest {

--- a/packages/mbrc-core/src/wire/mod.rs
+++ b/packages/mbrc-core/src/wire/mod.rs
@@ -11,11 +11,11 @@ pub mod v4;
 
 use serde_json::Value;
 
+use crate::protocol::Platform;
 use crate::protocol::messages::{
     Cover, LastfmStatus, Lyrics, NowPlayingListTrack, OutputDevices, Page, PlayState, PlayerState,
     QueueType, RepeatMode, ShuffleMode, TrackDetails, TrackInfo,
 };
-use crate::protocol::Platform;
 
 /// Removes synchronized-lyrics (LRC) tags from a lyrics blob. Legacy clients
 /// (V4, V5) cannot render them, so their codecs strip; V6+ receives the LRC
@@ -30,16 +30,16 @@ pub fn strip_lrc(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'[' {
-            if let Some(rel) = bytes[i + 1..].iter().position(|&b| b == b']') {
-                let content = &input[i + 1..i + 1 + rel];
-                if is_lrc_tag(content) {
-                    i += rel + 2; // past the closing ']'
-                    if i < bytes.len() && bytes[i] == b' ' {
-                        i += 1; // consume one trailing space
-                    }
-                    continue;
+        if bytes[i] == b'['
+            && let Some(rel) = bytes[i + 1..].iter().position(|&b| b == b']')
+        {
+            let content = &input[i + 1..i + 1 + rel];
+            if is_lrc_tag(content) {
+                i += rel + 2; // past the closing ']'
+                if i < bytes.len() && bytes[i] == b' ' {
+                    i += 1; // consume one trailing space
                 }
+                continue;
             }
         }
         // Copy one whole UTF-8 char so multibyte lyrics stay intact.

--- a/packages/mbrc-core/src/wire/v4.rs
+++ b/packages/mbrc-core/src/wire/v4.rs
@@ -7,14 +7,14 @@
 //! and lets a V6 codec render/parse the same data differently without touching
 //! handlers.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use super::{sanitize_lyrics, strip_lrc, WireCodec};
+use super::{WireCodec, sanitize_lyrics, strip_lrc};
+use crate::protocol::Platform;
 use crate::protocol::messages::{
     Cover, LastfmStatus, Lyrics, NowPlayingListTrack, OutputDevices, Page, PlayState, PlayerState,
     QueueType, RepeatMode, ShuffleMode, TrackDetails, TrackInfo,
 };
-use crate::protocol::Platform;
 
 /// The V4 wire codec (stateless).
 pub struct V4Codec;
@@ -184,10 +184,10 @@ impl WireCodec for V4Codec {
 
     fn track_details(&self, details: &TrackDetails) -> Value {
         let mut value = serde_json::to_value(details).unwrap_or_else(|_| json!({}));
-        if details.album_artist.is_empty() {
-            if let Some(obj) = value.as_object_mut() {
-                obj.insert("albumArtist".into(), Value::from("Unknown Artist"));
-            }
+        if details.album_artist.is_empty()
+            && let Some(obj) = value.as_object_mut()
+        {
+            obj.insert("albumArtist".into(), Value::from("Unknown Artist"));
         }
         value
     }

--- a/packages/mbrc-core/tests/fuzz_msgpack.rs
+++ b/packages/mbrc-core/tests/fuzz_msgpack.rs
@@ -13,7 +13,7 @@ use proptest::prelude::*;
 /// Decode `bytes` as each listed type, discarding the result. The only assertion
 /// is the absence of a panic (a control-flow property, not a value one).
 macro_rules! try_decode {
-    ($bytes:expr, $($t:ty),+ $(,)?) => {
+    ($bytes:expr_2021, $($t:ty),+ $(,)?) => {
         $( let _ = rmp_serde::from_slice::<$t>($bytes); )+
     };
 }

--- a/packages/mbrc-core/tests/golden_replay.rs
+++ b/packages/mbrc-core/tests/golden_replay.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use serde_json::Value;
 
-use mbrc_capture::{endpoint_schemas, Frame};
+use mbrc_capture::{Frame, endpoint_schemas};
 use mbrc_core::config::Config;
 use mbrc_core::ffi::types::NotificationType;
 use mbrc_core::protocol::messages::*;

--- a/packages/mbrc-core/tests/golden_replay.rs
+++ b/packages/mbrc-core/tests/golden_replay.rs
@@ -9,6 +9,8 @@
 //! shows must appear in the core's output with the same type (the core may add
 //! optional fields the golden happened not to exercise).
 
+#![allow(clippy::unwrap_used)]
+
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::sync::Arc;

--- a/packages/mbrc-core/tests/handshake.rs
+++ b/packages/mbrc-core/tests/handshake.rs
@@ -1,6 +1,8 @@
 //! Integration test: start the real TCP server and drive a V4 handshake plus
 //! keepalive/health frames over a socket, asserting the wire replies.
 
+#![allow(clippy::unwrap_used)]
+
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::sync::Arc;

--- a/packages/mbrc-discovery/src/lib.rs
+++ b/packages/mbrc-discovery/src/lib.rs
@@ -12,6 +12,8 @@
 //! reachable only on a non-default interface - the original C# tool enumerated
 //! interfaces for the same reason.
 
+#![forbid(unsafe_code)]
+
 use std::net::{Ipv4Addr, SocketAddrV4, UdpSocket};
 use std::time::{Duration, Instant};
 

--- a/packages/mbrc-discovery/src/lib.rs
+++ b/packages/mbrc-discovery/src/lib.rs
@@ -159,13 +159,12 @@ pub fn discover_blocking(timeout: Duration) -> Result<Vec<Discovered>, String> {
         for (_ip, socket) in &sockets {
             match socket.recv_from(&mut buf) {
                 Ok((n, _src)) => {
-                    if let Some(d) = parse_notify(&buf[..n]) {
-                        if !found
+                    if let Some(d) = parse_notify(&buf[..n])
+                        && !found
                             .iter()
                             .any(|e| e.address == d.address && e.port == d.port)
-                        {
-                            found.push(d);
-                        }
+                    {
+                        found.push(d);
                     }
                 }
                 Err(ref e)

--- a/packages/mbrc-helper/src/firewall/com.rs
+++ b/packages/mbrc-helper/src/firewall/com.rs
@@ -6,18 +6,18 @@
 
 use super::{Error, FirewallPolicy, Result};
 
-use windows::core::{Interface, BSTR};
 use windows::Win32::Foundation::{E_ACCESSDENIED, VARIANT_TRUE};
 use windows::Win32::NetworkManagement::WindowsFirewall::{
-    INetFwPolicy2, INetFwRule, NetFwPolicy2, NetFwRule, NET_FW_ACTION_ALLOW,
-    NET_FW_IP_PROTOCOL_TCP, NET_FW_PROFILE2_DOMAIN, NET_FW_PROFILE2_PRIVATE,
-    NET_FW_PROFILE2_PUBLIC, NET_FW_PROFILE_TYPE2, NET_FW_RULE_DIR_IN,
+    INetFwPolicy2, INetFwRule, NET_FW_ACTION_ALLOW, NET_FW_IP_PROTOCOL_TCP, NET_FW_PROFILE_TYPE2,
+    NET_FW_PROFILE2_DOMAIN, NET_FW_PROFILE2_PRIVATE, NET_FW_PROFILE2_PUBLIC, NET_FW_RULE_DIR_IN,
+    NetFwPolicy2, NetFwRule,
 };
 use windows::Win32::System::Com::{
-    CoCreateInstance, CoInitializeEx, IDispatch, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+    CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx, IDispatch,
 };
 use windows::Win32::System::Ole::IEnumVARIANT;
 use windows::Win32::System::Variant::VARIANT;
+use windows::core::{BSTR, Interface};
 
 /// Maps a COM failure onto the two cases the caller distinguishes.
 fn map_err(e: windows::core::Error) -> Error {

--- a/packages/mbrc-helper/src/log.rs
+++ b/packages/mbrc-helper/src/log.rs
@@ -69,9 +69,9 @@ pub fn note_environment() {
 /// identity - the ordinary desktop install, and by far the common case.
 #[cfg(windows)]
 fn package_family_name() -> Option<String> {
-    use windows::core::PWSTR;
     use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS};
     use windows::Win32::Storage::Packaging::Appx::GetCurrentPackageFamilyName;
+    use windows::core::PWSTR;
 
     let mut length: u32 = 0;
     // SAFETY: the documented probe - a null buffer with a zero length asks for

--- a/packages/mbrc-helper/src/main.rs
+++ b/packages/mbrc-helper/src/main.rs
@@ -199,7 +199,7 @@ fn run_update(request: &update::Request<'_>) -> u8 {
 
 #[cfg(windows)]
 fn run_firewall(port: u16) -> u8 {
-    use firewall::{ensure_rule, RULE_NAME};
+    use firewall::{RULE_NAME, ensure_rule};
 
     let policy = match firewall::com::ComPolicy::new() {
         Ok(policy) => policy,

--- a/packages/mbrc-helper/src/update.rs
+++ b/packages/mbrc-helper/src/update.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use mbrc_release::{is_bare_filename, verify_manifest_with, Manifest, TrustedKey, TRUSTED_KEYS};
+use mbrc_release::{Manifest, TRUSTED_KEYS, TrustedKey, is_bare_filename, verify_manifest_with};
 
 /// Asset names the core stages alongside the payload.
 const MANIFEST_ASSET: &str = "manifest.json";
@@ -400,10 +400,10 @@ fn prune_backups(plan: &Plan, keep: &str) {
             continue;
         }
         let path = entry.path();
-        if path.is_dir() {
-            if let Err(e) = std::fs::remove_dir_all(&path) {
-                crate::log::line(&format!("could not remove {}: {e}", path.display()));
-            }
+        if path.is_dir()
+            && let Err(e) = std::fs::remove_dir_all(&path)
+        {
+            crate::log::line(&format!("could not remove {}: {e}", path.display()));
         }
     }
 }
@@ -427,10 +427,10 @@ pub fn clear_staged(plan: &Plan) {
     }
     if let Some(updates) = plan.staged.parent() {
         let marker = updates.join("pending.json");
-        if marker.exists() {
-            if let Err(e) = std::fs::remove_file(&marker) {
-                crate::log::line(&format!("could not remove {}: {e}", marker.display()));
-            }
+        if marker.exists()
+            && let Err(e) = std::fs::remove_file(&marker)
+        {
+            crate::log::line(&format!("could not remove {}: {e}", marker.display()));
         }
     }
 }
@@ -543,7 +543,7 @@ fn failed(path: &Path, e: std::io::Error) -> Error {
 fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
     use windows::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
     use windows::Win32::System::Threading::{
-        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+        OpenProcess, PROCESS_SYNCHRONIZE, WaitForSingleObject,
     };
 
     // SAFETY: a pid is a value, not a pointer; the handle is closed on both

--- a/packages/mbrc-release/build.rs
+++ b/packages/mbrc-release/build.rs
@@ -47,7 +47,10 @@ fn main() {
     if keys.is_empty() {
         // Not fatal: the crate must still build in a fresh checkout before the
         // keys are dropped in. Verification fails closed at runtime instead.
-        println!("cargo:warning=no release public keys in {} — signature verification will reject every manifest", keys_dir.display());
+        println!(
+            "cargo:warning=no release public keys in {} — signature verification will reject every manifest",
+            keys_dir.display()
+        );
     }
 
     // A local testing key is supported and gitignored, but a build carrying

--- a/packages/mbrc-release/src/check.rs
+++ b/packages/mbrc-release/src/check.rs
@@ -16,7 +16,7 @@ use crate::{
     http::HttpClient,
     manifest::{Channel, Manifest},
     state::UpdateState,
-    verify::{verify_manifest_with, TrustedKey, TRUSTED_KEYS},
+    verify::{TRUSTED_KEYS, TrustedKey, verify_manifest_with},
     version,
 };
 

--- a/packages/mbrc-release/src/lib.rs
+++ b/packages/mbrc-release/src/lib.rs
@@ -39,19 +39,19 @@ pub mod winhttp;
 
 pub use error::{Result, UpdateError};
 pub use manifest::{
-    is_bare_filename, Artifact, Artifacts, Channel, FileEntry, Manifest, SCHEMA_VERSION,
+    Artifact, Artifacts, Channel, FileEntry, Manifest, SCHEMA_VERSION, is_bare_filename,
 };
 pub use verify::{
-    verify_bundled_file, verify_manifest, verify_manifest_with, verify_sha512, verify_signature,
-    verify_signature_with, TrustedKey, TRUSTED_KEYS,
+    TRUSTED_KEYS, TrustedKey, verify_bundled_file, verify_manifest, verify_manifest_with,
+    verify_sha512, verify_signature, verify_signature_with,
 };
 
 #[cfg(feature = "client")]
-pub use check::{check, AvailableUpdate, CheckOptions, CheckOutcome};
+pub use check::{AvailableUpdate, CheckOptions, CheckOutcome, check};
 #[cfg(feature = "client")]
 pub use http::{HttpClient, HttpResponse};
 #[cfg(feature = "client")]
-pub use stage::{clear_staged, read_pending, stage, Pending, StagedUpdate};
+pub use stage::{Pending, StagedUpdate, clear_staged, read_pending, stage};
 #[cfg(feature = "client")]
 pub use state::UpdateState;
 #[cfg(all(feature = "client", windows))]

--- a/packages/mbrc-release/src/stage.rs
+++ b/packages/mbrc-release/src/stage.rs
@@ -22,13 +22,13 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{
     check::{AvailableUpdate, MANIFEST_ASSET, SIGNATURE_ASSET},
     error::{Result, UpdateError},
     http::HttpClient,
-    manifest::{is_bare_filename, Manifest},
+    manifest::{Manifest, is_bare_filename},
     verify::verify_sha512,
 };
 

--- a/packages/mbrc-release/src/state.rs
+++ b/packages/mbrc-release/src/state.rs
@@ -12,7 +12,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
+use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::error::{Result, UpdateError};
 

--- a/packages/mbrc-release/src/winhttp.rs
+++ b/packages/mbrc-release/src/winhttp.rs
@@ -22,17 +22,17 @@
 use std::ffi::c_void;
 use std::ptr::{null, null_mut};
 
-use windows_sys::Win32::Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER};
+use windows_sys::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, GetLastError};
 use windows_sys::Win32::Networking::WinHttp::{
-    WinHttpAddRequestHeaders, WinHttpCloseHandle, WinHttpConnect, WinHttpCrackUrl, WinHttpOpen,
-    WinHttpOpenRequest, WinHttpQueryDataAvailable, WinHttpQueryHeaders, WinHttpReadData,
-    WinHttpReceiveResponse, WinHttpSendRequest, WinHttpSetOption, WinHttpSetTimeouts,
     URL_COMPONENTS, WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY, WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
     WINHTTP_ACCESS_TYPE_NAMED_PROXY, WINHTTP_ADDREQ_FLAG_ADD, WINHTTP_ADDREQ_FLAG_REPLACE,
     WINHTTP_FLAG_SECURE, WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2, WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3,
     WINHTTP_INTERNET_SCHEME_HTTPS, WINHTTP_OPTION_REDIRECT_POLICY,
     WINHTTP_OPTION_REDIRECT_POLICY_DISALLOW_HTTPS_TO_HTTP, WINHTTP_OPTION_SECURE_PROTOCOLS,
     WINHTTP_QUERY_ETAG, WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_QUERY_STATUS_CODE,
+    WinHttpAddRequestHeaders, WinHttpCloseHandle, WinHttpConnect, WinHttpCrackUrl, WinHttpOpen,
+    WinHttpOpenRequest, WinHttpQueryDataAvailable, WinHttpQueryHeaders, WinHttpReadData,
+    WinHttpReceiveResponse, WinHttpSendRequest, WinHttpSetOption, WinHttpSetTimeouts,
 };
 
 use crate::error::{Result, UpdateError};
@@ -676,12 +676,14 @@ mod tests {
             "an unknown protocol bit was accepted"
         );
         // And the mask the fallback uses is one it does know.
-        assert!(set_option(
-            &client.session,
-            WINHTTP_OPTION_SECURE_PROTOCOLS,
-            WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2
-        )
-        .is_ok());
+        assert!(
+            set_option(
+                &client.session,
+                WINHTTP_OPTION_SECURE_PROTOCOLS,
+                WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/packages/mbrc-release/tests/check_tests.rs
+++ b/packages/mbrc-release/tests/check_tests.rs
@@ -12,9 +12,9 @@
 
 mod support;
 
-use mbrc_release::{check, Channel, CheckOptions, CheckOutcome, UpdateError, UpdateState};
+use mbrc_release::{Channel, CheckOptions, CheckOutcome, UpdateError, UpdateState, check};
 use support::{OfflineHttp, StubHttp, TEST_KEYS};
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 const MANIFEST: &str = include_str!("fixtures/manifest.json");
 const SIGNATURE: &str = include_str!("fixtures/manifest.json.minisig");
@@ -353,13 +353,15 @@ fn a_failing_check_backs_off_instead_of_retrying_on_every_tick() {
     .unwrap();
     assert!(matches!(outcome, CheckOutcome::NotDue), "{outcome:?}");
 
-    assert!(check(
-        &OfflineHttp,
-        &options("1.4.0.0"),
-        &mut state,
-        at("2026-08-04T10:20:00Z")
-    )
-    .is_err());
+    assert!(
+        check(
+            &OfflineHttp,
+            &options("1.4.0.0"),
+            &mut state,
+            at("2026-08-04T10:20:00Z")
+        )
+        .is_err()
+    );
     assert_eq!(state.consecutive_failures, 2);
 
     // A check that works clears the streak.

--- a/packages/mbrc-release/tests/check_tests.rs
+++ b/packages/mbrc-release/tests/check_tests.rs
@@ -8,6 +8,8 @@
 //! vary the *running* version instead - which is the input that actually varies
 //! in the field.
 
+#![allow(clippy::unwrap_used)]
+
 mod support;
 
 use mbrc_release::{check, Channel, CheckOptions, CheckOutcome, UpdateError, UpdateState};

--- a/packages/mbrc-release/tests/stage_tests.rs
+++ b/packages/mbrc-release/tests/stage_tests.rs
@@ -6,6 +6,8 @@
 //! opaque - staging copies them to disk for the helper to re-verify, and never
 //! looks at them.
 
+#![allow(clippy::unwrap_used)]
+
 mod support;
 
 use std::io::Write;

--- a/packages/mbrc-release/tests/stage_tests.rs
+++ b/packages/mbrc-release/tests/stage_tests.rs
@@ -14,15 +14,14 @@ use std::io::Write;
 use std::path::Path;
 
 use mbrc_release::{
-    clear_staged,
+    AvailableUpdate, Channel, Manifest, UpdateError, clear_staged,
     manifest::{Artifact, Artifacts, FileEntry},
     read_pending, stage,
     stage::{PENDING_FILE, PENDING_SCHEMA, STAGING_DIR},
-    AvailableUpdate, Channel, Manifest, UpdateError,
 };
 use sha2::{Digest, Sha512};
 use support::StubHttp;
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 const ZIP_URL: &str = "https://assets.test/musicbee_remote_1.6.0.zip";
 const NOW: &str = "2026-08-04T10:00:00Z";

--- a/packages/mbrc-release/tests/verify_tests.rs
+++ b/packages/mbrc-release/tests/verify_tests.rs
@@ -9,7 +9,7 @@
 //! ```
 
 use mbrc_release::{
-    verify_bundled_file, verify_sha512, verify_signature_with, Manifest, TrustedKey, TRUSTED_KEYS,
+    Manifest, TRUSTED_KEYS, TrustedKey, verify_bundled_file, verify_sha512, verify_signature_with,
 };
 
 const GOLDEN: &str = include_str!("fixtures/manifest.json");

--- a/packages/mbrc-wire/src/lib.rs
+++ b/packages/mbrc-wire/src/lib.rs
@@ -6,6 +6,8 @@
 //! server side - so the framing, message shape, and handshake automation have a
 //! single definition instead of a copy per tool.
 
+#![forbid(unsafe_code)]
+
 use serde::{Deserialize, Serialize};
 
 /// Line terminator for the legacy CRLF-JSON protocol.

--- a/packages/mbrc-wire/tests/fuzz.rs
+++ b/packages/mbrc-wire/tests/fuzz.rs
@@ -7,7 +7,7 @@
 //! cases under `cargo test` (and in CI/coverage) instead.
 
 use mbrc_wire::{
-    frame_line, parse_context, parse_lenient, sanitize_ios_quotes, FrameAccumulator, TERMINATOR,
+    FrameAccumulator, TERMINATOR, frame_line, parse_context, parse_lenient, sanitize_ios_quotes,
 };
 use proptest::prelude::*;
 use serde_json::Value;

--- a/tools/api-debugger/src-tauri/Cargo.toml
+++ b/tools/api-debugger/src-tauri/Cargo.toml
@@ -47,3 +47,6 @@ mbrc-capture = { path = "../../../packages/mbrc-capture" }
 [lints.clippy]
 too_long_first_doc_paragraph = "warn"
 undocumented_unsafe_blocks = "warn"
+cognitive_complexity = "warn"
+too_many_lines = "warn"
+unwrap_used = "warn"

--- a/tools/api-debugger/src-tauri/src/connection.rs
+++ b/tools/api-debugger/src-tauri/src/connection.rs
@@ -85,7 +85,7 @@ pub struct ConnectionState {
 impl ConnectionState {
     /// Installs (or clears) the connection for a slot, tearing down any previous.
     fn replace(&self, slot: &str, conn: Option<Connection>) {
-        let mut guard = self.slots.lock().unwrap();
+        let mut guard = self.slots.lock().expect("slots mutex poisoned");
         if let Some(old) = guard.remove(slot) {
             old.reader.abort();
             old.writer.abort();
@@ -98,7 +98,7 @@ impl ConnectionState {
     fn sender(&self, slot: &str) -> Option<mpsc::UnboundedSender<String>> {
         self.slots
             .lock()
-            .unwrap()
+            .expect("slots mutex poisoned")
             .get(slot)
             .map(|c| c.outbound.clone())
     }

--- a/tools/api-debugger/src-tauri/src/proxy.rs
+++ b/tools/api-debugger/src-tauri/src/proxy.rs
@@ -138,7 +138,7 @@ impl ProxyState {
     /// Installs a new proxy, tearing down any previous one (signal shutdown so
     /// live sessions unwind, then abort the accept loop).
     fn replace(&self, handle: Option<ProxyHandle>) {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock().expect("proxy handle mutex poisoned");
         if let Some(old) = guard.take() {
             let _ = old.shutdown.send(true);
             old.accept.abort();
@@ -352,7 +352,11 @@ async fn handle_session(
     // Either direction closing (or shutdown) ends the session.
     let result = tokio::try_join!(flatten(c2s), flatten(s2c));
 
-    let by = session.closed_by.lock().unwrap().unwrap_or("proxy");
+    let by = session
+        .closed_by
+        .lock()
+        .expect("closed_by mutex poisoned")
+        .unwrap_or("proxy");
     let reason = match &result {
         Ok(_) => "eof".to_string(),
         Err(e) => format!("error:{e}"),
@@ -406,7 +410,7 @@ where
             // EOF: record which side hung up, then half-close so the peer sees it.
             // Scoped because a `MutexGuard` is not Send across the await below.
             {
-                let mut cb = session.closed_by.lock().unwrap();
+                let mut cb = session.closed_by.lock().expect("closed_by mutex poisoned");
                 if cb.is_none() {
                     *cb = Some(if dir == "c2s" { "client" } else { "server" });
                 }
@@ -479,7 +483,10 @@ async fn maybe_handshake(session: &Arc<Session>, record: &Frame) {
                 .and_then(|f| f.get("data"))
                 .and_then(|d| d.as_str())
             {
-                *session.client_type.lock().unwrap() = Some(ct.to_string());
+                *session
+                    .client_type
+                    .lock()
+                    .expect("client_type mutex poisoned") = Some(ct.to_string());
             }
         }
         Some("protocol") => {
@@ -489,7 +496,11 @@ async fn maybe_handshake(session: &Arc<Session>, record: &Frame) {
                 .and_then(|f| f.get("data"))
                 .and_then(|d| d.get("protocol_version"))
                 .and_then(|v| v.as_i64());
-            let client_type = session.client_type.lock().unwrap().clone();
+            let client_type = session
+                .client_type
+                .lock()
+                .expect("client_type mutex poisoned")
+                .clone();
             append_line(
                 &session.shared,
                 &meta_handshake(session.conn_id, client_type.as_deref(), protocol_version),

--- a/tools/mbrc-cli/src/capture.rs
+++ b/tools/mbrc-cli/src/capture.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use mbrc_capture::{meta_capture_start, meta_close, meta_handshake, meta_open, Frame};
+use mbrc_capture::{Frame, meta_capture_start, meta_close, meta_handshake, meta_open};
 use serde::Serialize;
 use tokio::fs::{File, OpenOptions};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};

--- a/tools/mbrc-cli/src/capture.rs
+++ b/tools/mbrc-cli/src/capture.rs
@@ -185,7 +185,11 @@ async fn handle_session(
 
     let result = tokio::try_join!(flatten(c2s), flatten(s2c));
 
-    let by = session.closed_by.lock().unwrap().unwrap_or("proxy");
+    let by = session
+        .closed_by
+        .lock()
+        .expect("closed_by mutex poisoned")
+        .unwrap_or("proxy");
     let reason = match &result {
         Ok(_) => "eof".to_string(),
         Err(e) => format!("error:{e}"),
@@ -217,7 +221,7 @@ where
         let n = src.read_until(b'\n', &mut buf).await?;
         if n == 0 {
             {
-                let mut cb = session.closed_by.lock().unwrap();
+                let mut cb = session.closed_by.lock().expect("closed_by mutex poisoned");
                 if cb.is_none() {
                     *cb = Some(if dir == "c2s" { "client" } else { "server" });
                 }
@@ -272,7 +276,10 @@ async fn maybe_handshake(session: &Arc<Session>, record: &Frame) {
                 .and_then(|f| f.get("data"))
                 .and_then(|d| d.as_str())
             {
-                *session.client_type.lock().unwrap() = Some(ct.to_string());
+                *session
+                    .client_type
+                    .lock()
+                    .expect("client_type mutex poisoned") = Some(ct.to_string());
             }
         }
         Some("protocol") => {
@@ -282,7 +289,11 @@ async fn maybe_handshake(session: &Arc<Session>, record: &Frame) {
                 .and_then(|f| f.get("data"))
                 .and_then(|d| d.get("protocol_version"))
                 .and_then(|v| v.as_i64());
-            let client_type = session.client_type.lock().unwrap().clone();
+            let client_type = session
+                .client_type
+                .lock()
+                .expect("client_type mutex poisoned")
+                .clone();
             append_line(
                 &session.shared,
                 &meta_handshake(session.conn_id, client_type.as_deref(), protocol_version),

--- a/tools/mbrc-cli/src/compare.rs
+++ b/tools/mbrc-cli/src/compare.rs
@@ -13,7 +13,7 @@
 use std::collections::BTreeSet;
 use std::process::ExitCode;
 
-use mbrc_capture::{endpoint_schemas, endpoint_values, FieldMap};
+use mbrc_capture::{FieldMap, endpoint_schemas, endpoint_values};
 
 use crate::args::{flag_value, has_flag};
 use crate::trim::read_all;

--- a/tools/mbrc-cli/src/fuzz.rs
+++ b/tools/mbrc-cli/src/fuzz.rs
@@ -22,8 +22,8 @@
 use std::process::ExitCode;
 use std::time::Duration;
 
-use mbrc_capture::{parse_line, Frame, Record};
-use mbrc_wire::{frame_line, parse_context, ClientHandshake, FrameAccumulator, CTX_PLAYER};
+use mbrc_capture::{Frame, Record, parse_line};
+use mbrc_wire::{CTX_PLAYER, ClientHandshake, FrameAccumulator, frame_line, parse_context};
 use serde_json::{Map, Value};
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;

--- a/tools/mbrc-cli/src/inspect.rs
+++ b/tools/mbrc-cli/src/inspect.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::process::ExitCode;
 
-use mbrc_capture::{parse_line, Record};
+use mbrc_capture::{Record, parse_line};
 
 /// Frame/meta tallies for a capture file.
 #[derive(Debug, Default, PartialEq, Eq)]

--- a/tools/mbrc-cli/src/main.rs
+++ b/tools/mbrc-cli/src/main.rs
@@ -3,6 +3,8 @@
 //! Subcommands: `discover`, `inspect`, `send`, `monitor`, `capture`, `trim`,
 //! `replay`, `fuzz`.
 
+#![forbid(unsafe_code)]
+
 use std::process::ExitCode;
 use std::time::Duration;
 

--- a/tools/mbrc-cli/src/monitor.rs
+++ b/tools/mbrc-cli/src/monitor.rs
@@ -25,11 +25,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use mbrc_wire::{frame_line, parse_context, ClientHandshake, FrameAccumulator};
-use serde_json::{json, Value};
+use mbrc_wire::{ClientHandshake, FrameAccumulator, frame_line, parse_context};
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::TcpStream;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 
 use crate::args::flag_value;
 
@@ -214,7 +214,7 @@ impl Conn {
             match tokio::time::timeout(remaining, self.rd.read(&mut buf)).await {
                 Err(_) => return Ok(None),
                 Ok(Ok(0)) => {
-                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "peer closed"))
+                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "peer closed"));
                 }
                 Ok(Ok(n)) => self.acc.push_bytes(&buf[..n]),
                 Ok(Err(e)) => return Err(e),
@@ -264,15 +264,15 @@ impl Conn {
                     return Err(io::Error::new(
                         io::ErrorKind::TimedOut,
                         format!("no reply for {context}"),
-                    ))
+                    ));
                 }
                 Some(line) => {
-                    if let Some((ctx, payload)) = self.handle_frame(&line).await? {
-                        if ctx == context {
-                            return Ok(payload);
-                        }
-                        // A broadcast slipped in while we waited; ignore it.
+                    if let Some((ctx, payload)) = self.handle_frame(&line).await?
+                        && ctx == context
+                    {
+                        return Ok(payload);
                     }
+                    // A broadcast slipped in while we waited; ignore it.
                 }
             }
         }
@@ -359,10 +359,11 @@ async fn sweep_browsetracks(
         }
 
         offset += items.len() as i32;
-        if let Some(t) = total {
-            if t >= 0 && offset >= t {
-                break;
-            }
+        if let Some(t) = total
+            && t >= 0
+            && offset >= t
+        {
+            break;
         }
     }
 
@@ -479,10 +480,10 @@ async fn pager_loop(
     let mut conn: Option<Conn> = None;
 
     loop {
-        if let Some(t) = until {
-            if Instant::now() >= t {
-                return;
-            }
+        if let Some(t) = until
+            && Instant::now() >= t
+        {
+            return;
         }
 
         // Ensure a live connection.
@@ -570,10 +571,10 @@ async fn subscriber_loop(
 ) {
     let mut backoff = Duration::from_millis(500);
     loop {
-        if let Some(t) = until {
-            if Instant::now() >= t {
-                return;
-            }
+        if let Some(t) = until
+            && Instant::now() >= t
+        {
+            return;
         }
 
         let mut conn = match Conn::connect(&cfg, false).await {

--- a/tools/mbrc-cli/src/monitor.rs
+++ b/tools/mbrc-cli/src/monitor.rs
@@ -504,7 +504,7 @@ async fn pager_loop(
             }
         }
 
-        let c = conn.as_mut().unwrap();
+        let Some(c) = conn.as_mut() else { continue };
         iter += 1;
         let start = Instant::now();
         let sweep = sweep_browsetracks(c, cfg.page_size, cfg.req_timeout).await;

--- a/tools/mbrc-cli/src/replay.rs
+++ b/tools/mbrc-cli/src/replay.rs
@@ -18,8 +18,8 @@ use std::collections::BTreeMap;
 use std::process::ExitCode;
 use std::time::Duration;
 
-use mbrc_capture::{parse_line, Frame, Record};
-use mbrc_wire::{frame_line, parse_context, ClientHandshake, FrameAccumulator, CTX_PLAYER};
+use mbrc_capture::{Frame, Record, parse_line};
+use mbrc_wire::{CTX_PLAYER, ClientHandshake, FrameAccumulator, frame_line, parse_context};
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -90,10 +90,10 @@ pub fn run(args: &[String]) -> ExitCode {
         }
     };
 
-    if let Some(path) = &out_path {
-        if let Err(e) = std::fs::write(path, &replay_contents) {
-            eprintln!("write {path} failed: {e}");
-        }
+    if let Some(path) = &out_path
+        && let Err(e) = std::fs::write(path, &replay_contents)
+    {
+        eprintln!("write {path} failed: {e}");
     }
 
     println!(
@@ -112,16 +112,16 @@ fn plan_connections(golden: &str) -> Vec<ReplayConn> {
     let mut order: Vec<u32> = Vec::new();
     let mut by_conn: BTreeMap<u32, Vec<Frame>> = BTreeMap::new();
     for line in golden.lines() {
-        if let Some(Record::Frame(f)) = parse_line(line) {
-            if f.dir == "c2s" {
-                by_conn
-                    .entry(f.conn_id)
-                    .or_insert_with(|| {
-                        order.push(f.conn_id);
-                        Vec::new()
-                    })
-                    .push(*f);
-            }
+        if let Some(Record::Frame(f)) = parse_line(line)
+            && f.dir == "c2s"
+        {
+            by_conn
+                .entry(f.conn_id)
+                .or_insert_with(|| {
+                    order.push(f.conn_id);
+                    Vec::new()
+                })
+                .push(*f);
         }
     }
 

--- a/tools/mbrc-cli/src/replay.rs
+++ b/tools/mbrc-cli/src/replay.rs
@@ -114,11 +114,13 @@ fn plan_connections(golden: &str) -> Vec<ReplayConn> {
     for line in golden.lines() {
         if let Some(Record::Frame(f)) = parse_line(line) {
             if f.dir == "c2s" {
-                by_conn.entry(f.conn_id).or_insert_with(|| {
-                    order.push(f.conn_id);
-                    Vec::new()
-                });
-                by_conn.get_mut(&f.conn_id).unwrap().push(*f);
+                by_conn
+                    .entry(f.conn_id)
+                    .or_insert_with(|| {
+                        order.push(f.conn_id);
+                        Vec::new()
+                    })
+                    .push(*f);
             }
         }
     }

--- a/tools/mbrc-cli/src/send.rs
+++ b/tools/mbrc-cli/src/send.rs
@@ -14,7 +14,7 @@
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
-use mbrc_wire::{frame_line, parse_context, ClientHandshake, FrameAccumulator};
+use mbrc_wire::{ClientHandshake, FrameAccumulator, frame_line, parse_context};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -137,12 +137,12 @@ async fn run_async(
                 println!("> {reply}");
                 // The plugin only accepts commands once we answer the `player` echo with
                 // `protocol`, so the queued command goes now.
-                if ctx == mbrc_wire::CTX_PLAYER {
-                    if let Some(cmd) = command.take() {
-                        let _ = wr.write_all(frame_line(&cmd).as_bytes()).await;
-                        let _ = wr.flush().await;
-                        println!("> {cmd}");
-                    }
+                if ctx == mbrc_wire::CTX_PLAYER
+                    && let Some(cmd) = command.take()
+                {
+                    let _ = wr.write_all(frame_line(&cmd).as_bytes()).await;
+                    let _ = wr.flush().await;
+                    println!("> {cmd}");
                 }
             }
         }

--- a/tools/mbrc-cli/src/serve.rs
+++ b/tools/mbrc-cli/src/serve.rs
@@ -13,8 +13,8 @@ use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
 
-use mbrc_capture::{parse_line, Record};
-use mbrc_wire::{frame_line, parse_context, FrameAccumulator};
+use mbrc_capture::{Record, parse_line};
+use mbrc_wire::{FrameAccumulator, frame_line, parse_context};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -66,21 +66,21 @@ fn build_responses(contents: &str) -> Responses {
 
     let mut seq_ctx: BTreeMap<u64, String> = BTreeMap::new();
     for f in &frames {
-        if f.dir == "c2s" {
-            if let Some(c) = f.context() {
-                seq_ctx.insert(f.seq, c.to_string());
-            }
+        if f.dir == "c2s"
+            && let Some(c) = f.context()
+        {
+            seq_ctx.insert(f.seq, c.to_string());
         }
     }
 
     let mut out: Responses = BTreeMap::new();
     for f in &frames {
-        if f.dir == "s2c" {
-            if let Some(ctx) = f.reply_to.and_then(|r| seq_ctx.get(&r)) {
-                let bucket = out.entry(ctx.clone()).or_default();
-                if !bucket.contains(&f.raw) {
-                    bucket.push(f.raw.clone());
-                }
+        if f.dir == "s2c"
+            && let Some(ctx) = f.reply_to.and_then(|r| seq_ctx.get(&r))
+        {
+            let bucket = out.entry(ctx.clone()).or_default();
+            if !bucket.contains(&f.raw) {
+                bucket.push(f.raw.clone());
             }
         }
     }

--- a/tools/mbrc-cli/src/trim.rs
+++ b/tools/mbrc-cli/src/trim.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use mbrc_capture::{trim_capture, PLACEHOLDER_PNG_B64};
+use mbrc_capture::{PLACEHOLDER_PNG_B64, trim_capture};
 
 use crate::args::flag_value;
 

--- a/tools/mbrc-lint/src/main.rs
+++ b/tools/mbrc-lint/src/main.rs
@@ -6,6 +6,8 @@
 //!
 //! Usage: `mbrc-lint --staged | --diff <range> | --all | <path>...`
 
+#![forbid(unsafe_code)]
+
 mod rules;
 mod scan;
 

--- a/tools/mbrc-lint/src/main.rs
+++ b/tools/mbrc-lint/src/main.rs
@@ -56,10 +56,10 @@ fn main() -> ExitCode {
         found.extend(rules::check_paths(&scanned, &repo));
         found.sort_by_key(|f| (f.line, f.rule));
         for f in found {
-            if let Some(ranges) = &ranges {
-                if !ranges.iter().any(|(a, b)| f.line <= *b && f.end >= *a) {
-                    continue;
-                }
+            if let Some(ranges) = &ranges
+                && !ranges.iter().any(|(a, b)| f.line <= *b && f.end >= *a)
+            {
+                continue;
             }
             findings += 1;
             println!("{}:{}: [{}] {}", path.display(), f.line, f.rule, f.message);

--- a/tools/mbrc-lint/src/rules.rs
+++ b/tools/mbrc-lint/src/rules.rs
@@ -261,37 +261,37 @@ fn content_rules(
         });
     }
 
-    if let Some(hit) = BANNED.iter().find(|p| text.contains(**p)) {
-        if !scan.allowed("banned-phrase", line) {
-            out.push(Finding {
-                line,
-                end,
-                rule: "banned-phrase",
-                message: format!("filler: \"{hit}\""),
-            });
-        }
+    if let Some(hit) = BANNED.iter().find(|p| text.contains(**p))
+        && !scan.allowed("banned-phrase", line)
+    {
+        out.push(Finding {
+            line,
+            end,
+            rule: "banned-phrase",
+            message: format!("filler: \"{hit}\""),
+        });
     }
 
-    if let Some(hit) = HISTORY.iter().find(|p| text.contains(**p)) {
-        if !scan.allowed("history-narration", line) {
-            out.push(Finding {
-                line,
-                end,
-                rule: "history-narration",
-                message: format!("history narration: \"{hit}\". Git holds that"),
-            });
-        }
+    if let Some(hit) = HISTORY.iter().find(|p| text.contains(**p))
+        && !scan.allowed("history-narration", line)
+    {
+        out.push(Finding {
+            line,
+            end,
+            rule: "history-narration",
+            message: format!("history narration: \"{hit}\". Git holds that"),
+        });
     }
 
-    if let Some(hit) = HEDGING.iter().find(|p| text.contains(**p)) {
-        if !scan.allowed("hedging", line) {
-            out.push(Finding {
-                line,
-                end,
-                rule: "hedging",
-                message: format!("hedging: \"{hit}\". Say what is true, or find out"),
-            });
-        }
+    if let Some(hit) = HEDGING.iter().find(|p| text.contains(**p))
+        && !scan.allowed("hedging", line)
+    {
+        out.push(Finding {
+            line,
+            end,
+            rule: "hedging",
+            message: format!("hedging: \"{hit}\". Say what is true, or find out"),
+        });
     }
 
     // Whole word and upper case, or a time format like mm:ss.xxx reads as one.
@@ -299,15 +299,14 @@ fn content_rules(
         original
             .split(|c: char| !c.is_ascii_alphanumeric())
             .any(|w| w == **p)
-    }) {
-        if !scan.allowed("placeholder", line) {
-            out.push(Finding {
-                line,
-                end,
-                rule: "placeholder",
-                message: format!("{hit} marker. Open an issue, or do it"),
-            });
-        }
+    }) && !scan.allowed("placeholder", line)
+    {
+        out.push(Finding {
+            line,
+            end,
+            rule: "placeholder",
+            message: format!("{hit} marker. Open an issue, or do it"),
+        });
     }
 
     let planning = PLANNING.iter().find(|p| contains_word(text, p));
@@ -318,24 +317,25 @@ fn content_rules(
                 .starts_with(|c: char| c.is_ascii_digit())
         })
     });
-    if let Some(hit) = planning.or(numbered) {
-        if !scan.allowed("planning-leftover", line) {
-            out.push(Finding {
-                line,
-                end,
-                rule: "planning-leftover",
-                message: format!(
-                    "plan vocabulary: \"{hit}\". Describe the code, not the schedule it arrived on"
-                ),
-            });
-        }
+    if let Some(hit) = planning.or(numbered)
+        && !scan.allowed("planning-leftover", line)
+    {
+        out.push(Finding {
+            line,
+            end,
+            rule: "planning-leftover",
+            message: format!(
+                "plan vocabulary: \"{hit}\". Describe the code, not the schedule it arrived on"
+            ),
+        });
     }
 
     let dated = ANECDOTE.iter().find(|p| text.contains(**p)).copied();
     let dated = dated.or_else(|| iso_date(text).map(|_| "a date"));
-    if let Some(hit) = dated {
-        if !scan.allowed("dated-anecdote", line) {
-            out.push(Finding {
+    if let Some(hit) = dated
+        && !scan.allowed("dated-anecdote", line)
+    {
+        out.push(Finding {
                 line,
                 end,
                 rule: "dated-anecdote",
@@ -343,7 +343,6 @@ fn content_rules(
                     "dated anecdote ({hit}). Keep the finding, move the measurement to the commit message"
                 ),
             });
-        }
     }
 }
 


### PR DESCRIPTION
Five things the workspace was relying on habit for, and one edition move.

## Lints

- **`#![forbid(unsafe_code)]`** in the six crates that hold none:
  mbrc-wire, mbrc-discovery, mbrc-capture, mbrc-buildinfo, mbrc-cli,
  mbrc-lint. The unsafe that exists is inherent to three places (FFI,
  COM, WinHTTP) and now stays there by rule. It cannot be a workspace
  lint: cargo rejects a member that both inherits `workspace.lints` and
  sets its own.
- **`clippy::unwrap_used`** as a workspace warn, with a `clippy.toml`
  that exempts tests. The property already held: seven sites in shipped
  code, six of them a mutex lock that now names the lock it guards.
  `monitor` unwrapped an Option the loop above had just proved is Some
  (now a let-else), and `trim`/`replay` looked a map key up twice where
  the entry API returns the value.
- The **api-debugger workspace** had drifted to two of the four lints
  under a comment claiming it mirrors the root. It now carries all of
  them; the new rule found seven more mutex locks in the proxy and the
  connection registry.

## CI

`rust.yml` cross-built i686 but ran the suite only on x86_64, so
everything 32-bit-specific at *runtime* was unverified: the redb store
and its cache sizing, the paging index's ordinal arithmetic, anything
assuming a 64-bit usize. It now runs mbrc-core and mbrc-wire on
i686-pc-windows-msvc, which is the command CLAUDE.md already documented
for local runs.

## Edition 2024

Taken for one reason in particular: it makes `unsafe_op_in_unsafe_fn`
the default, so an `unsafe fn` body is no longer implicitly unsafe
throughout. With 61 unsafe blocks across the FFI boundary, COM and
WinHTTP, that is the lint this workspace most wants.

Three mechanical parts: `cargo fix --edition` rewrote the 19 FFI exports
to `#[unsafe(no_mangle)]` and one macro matcher to `expr_2021`; rustfmt's
2024 style edition reorders imports; and `clippy --fix` collapsed 41
nested `if`/`if let` pairs now that let-chains are stable.

The risk in that list is csbindgen: it reads the `#[no_mangle]` surface
to generate the C# bindings. `NativeBridge.Generated.cs` regenerates
byte-identical, and the live test below is the other half of that proof.

## Verification

Gates on the pinned 1.98 toolchain: `cargo fmt`, `clippy -D warnings`,
the workspace suite (25 suites), `cargo doc` with the rustdoc gate, the
i686 cross-build under the plugin profile, and the new i686 test run
(241 tests in mbrc-core). Same for the api-debugger's own workspace.

**Live, against MusicBee** with a Debug build of both DLLs deployed:

- core initialized, server on :3000, discovery and mDNS up - the FFI
  exports still resolve after the `#[unsafe(no_mangle)]` rewrite
- library reconciled: 1443 albums, 15751 tracks, cover cache built
- commands served over the wire: `playerstatus`, `browsetracks`
  (total 15751, paged), `browsealbums` (total 1444), `nowplayingcover`
  (status 200, JPEG bytes back)
- 19 client frames, zero ERROR/WARN/panic lines in `mbrc-core.log`
- clean shutdown: mDNS goodbye, server stopped, core shut down

Not covered: a real Android or iOS client, and the C# Configure panel.
