### PR TITLE
build: trim dev debug info, check overflow in the plugin profile, and fix an out-of-range paging offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,12 @@ mbrc-discovery = { path = "packages/mbrc-discovery" }
 # workspace dependency's default features.
 mbrc-release = { path = "packages/mbrc-release", default-features = false }
 
+# Backtraces keep file and line, without the full type information that made
+# the dev artifacts the largest thing in the tree. Cargo never collects the
+# stale ones, so what a bump leaves behind is paid for until a sweep.
+[profile.dev]
+debug = "line-tables-only"
+
 # Size-optimised release build; only affects `--release` (cargo test uses dev).
 [profile.release]
 opt-level = "z"
@@ -91,3 +97,8 @@ strip = true
 [profile.plugin]
 inherits = "release"
 panic = "unwind"
+# Client-supplied numbers reach arithmetic here: the paging offset and limit,
+# and the ordinals they index the track store by. Wrapping silently turns a
+# hostile or buggy request into a page from the wrong place; panicking turns it
+# into the error code the FFI boundary's catch_unwind already returns.
+overflow-checks = true

--- a/packages/mbrc-core/src/server/commands/mod.rs
+++ b/packages/mbrc-core/src/server/commands/mod.rs
@@ -145,8 +145,16 @@ pub type Reply = (String, Value);
 pub type HandlerResult = Result<Vec<Reply>, String>;
 
 /// Extract `{offset, limit}` from a paginated request payload (0 when absent).
+///
+/// Values outside `i32` saturate rather than truncate. A cast would wrap
+/// `u32::MAX - 5` to `-6`, which the store then clamps to 0, so a request far
+/// past the end of the library answered with its first page.
 pub fn pagination(data: &Value) -> (i32, i32) {
-    let field = |key: &str| data.get(key).and_then(Value::as_i64).unwrap_or(0) as i32;
+    let field = |key: &str| {
+        data.get(key)
+            .and_then(Value::as_i64)
+            .map_or(0, |v| v.clamp(i32::MIN as i64, i32::MAX as i64) as i32)
+    };
     (field("offset"), field("limit"))
 }
 
@@ -364,6 +372,18 @@ mod audit {
         assert_eq!(as_int_lenient(&json!(" 50 ")), Some(50));
         assert_eq!(as_int_lenient(&json!("status")), None); // iOS position poll
         assert_eq!(as_int_lenient(&Value::Null), None);
+    }
+
+    #[test]
+    fn pagination_saturates_instead_of_wrapping() {
+        let far_past_the_end = json!({"offset": 4_294_967_290i64, "limit": 100});
+        assert_eq!(pagination(&far_past_the_end), (i32::MAX, 100));
+
+        let below_zero = json!({"offset": -4_294_967_290i64, "limit": 0});
+        assert_eq!(pagination(&below_zero), (i32::MIN, 0));
+
+        assert_eq!(pagination(&json!({"offset": 10, "limit": 5})), (10, 5));
+        assert_eq!(pagination(&json!({})), (0, 0));
     }
 
     #[test]


### PR DESCRIPTION
The two profile items from the hygiene review, plus a paging bug the
second one turned up.

## Profiles

- **`[profile.dev] debug = "line-tables-only"`**. There was no
  `[profile.dev]` at all, so every artifact carried full debug info. A
  fresh build of the workspace and its tests: **3.1 GiB -> 1.8 GiB**
  (fresh vs fresh, same command, not a sweep artefact). Backtraces still
  report file and line, checked by panicking a scratch test.
- **`overflow-checks = true` on `[profile.plugin]`**. A silent wrap in
  shipped code becomes a panic, which the FFI boundary's `catch_unwind`
  already turns into an error code. `release` is unchanged; only the
  profile the cdylib ships as moves.

## The paging bug

Probing the shipping build with an extreme offset found a real one:

```
before: {"offset":4294967290,"limit":100}  ->  offset -6, first page of the library
after:  {"offset":4294967290,"limit":100}  ->  offset 2147483647, empty page
```

`pagination` cast the JSON value straight to `i32`, truncating
`u32::MAX - 5` to `-6`; the store clamps a negative offset to 0, so a
request past the end of the library got its beginning. It now saturates
at the `i32` bounds.

Worth stating plainly: **`overflow-checks` does not catch this**. A cast
is a defined truncation, not arithmetic, so the profile change would
never have found it - the probe did. The boundary has to clamp what it
converts.

## V4 compatibility

The change is a no-op for anything inside `i32`, which is everything a
real client sends. Evidence:

- both golden schema conformance suites pass (android, ios)
- a unit test pins in-range values unchanged: `(10, 5)` and `(0, 0)`
- live, against MusicBee: offset 0 and offset 5000 return exactly what
  they returned before; only the out-of-range probe changes

I also ran `mbrc replay --golden` against the live server before and
after, and that comparison turned out **not** to be usable evidence: the
goldens were captured against a different library, and the summary
varies run to run on its own (72/12, then 71/13, then 71/14 identical
vs differing, with an occasional connection abort on main's own build).
Recording it here so the numbers are not mistaken for a regression.

## Verification

fmt, clippy `-D warnings`, the workspace suite (25 suites), the Release
build under `MSBuildCI`, and a live run of the shipping profile against
MusicBee: core initialized, library reconciled, `browsetracks`,
`browsealbums`, `nowplayingcover` all served, clean shutdown, no
ERROR/WARN/panic in the log.
