### PR TITLE
docs(core): point the public docs at items a reader can open

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,10 +74,13 @@ jobs:
         run: cargo clippy --all-targets --locked -- -D warnings
 
       # A doc link to a renamed item is invisible until someone reads the docs.
-      # Ambiguity (`stage` the module vs the function) is caught here too.
+      # Ambiguity (`stage` the module vs the function) is caught here too, as is
+      # a public doc pointing at a private item, which renders as bare text.
       - name: rustdoc (broken links as errors)
         env:
-          RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links -D rustdoc::invalid_html_tags
+          RUSTDOCFLAGS: >-
+            -D rustdoc::broken_intra_doc_links -D rustdoc::invalid_html_tags
+            -D rustdoc::private_intra_doc_links -D rustdoc::redundant_explicit_links
         run: cargo doc --no-deps --workspace --locked
 
       - name: test

--- a/packages/mbrc-core/src/diagnostics/bundle.rs
+++ b/packages/mbrc-core/src/diagnostics/bundle.rs
@@ -28,7 +28,7 @@ pub struct Inputs<'a> {
     /// carries the reproduction and not the user's whole history.
     pub log_offset: u64,
     /// When the capture began, Unix epoch milliseconds (UTC). Bounds which of
-    /// the other log files come along; see [`extra_logs`].
+    /// the other log files come along; see `extra_logs`.
     pub started_unix_ms: i64,
 }
 

--- a/packages/mbrc-core/src/diagnostics/capture.rs
+++ b/packages/mbrc-core/src/diagnostics/capture.rs
@@ -12,7 +12,7 @@
 //! - **One capture at a time.** A second start while one runs is refused, not
 //!   queued - two overlapping windows would make the offset a lie.
 //! - **A capture always ends.** A safety auto-stop restores the level after
-//!   [`MAX_CAPTURE`], so a user who forgets does not leave the plugin writing
+//!   `MAX_CAPTURE`, so a user who forgets does not leave the plugin writing
 //!   debug logs until MusicBee closes.
 //!
 //! The session survives a MusicBee restart (it is recorded in `capture.json`),
@@ -243,7 +243,7 @@ pub fn status_bytes() -> Option<Vec<u8>> {
 /// Called once from init. The log is appended across restarts rather than
 /// truncated, so the original offset still points at the start of the window -
 /// which is the whole reason a startup bug can be captured at all. A record
-/// older than [`MAX_CAPTURE`] is dropped rather than resumed into an instant
+/// older than `MAX_CAPTURE` is dropped rather than resumed into an instant
 /// expiry, and a session that is already live is left alone: a port change
 /// re-inits the core without clearing this module's state.
 pub fn resume_after_restart(core: &Core) {

--- a/packages/mbrc-core/src/mdns.rs
+++ b/packages/mbrc-core/src/mdns.rs
@@ -11,7 +11,7 @@
 //! - **A list of services, not one.** One daemon can hold several, so a second
 //!   endpoint later is another entry rather than a rewrite.
 //! - **The addresses are ours, not the crate's.** We hand `mdns-sd`
-//!   [`usable_ipv4_ifaces`], so it advertises what the panel's "Reachable at"
+//!   `usable_ipv4_ifaces`, so it advertises what the panel's "Reachable at"
 //!   row shows. mDNS carries no client-subnet hint, so we cannot pick *the*
 //!   reachable address, only avoid publishing loopback and APIPA.
 //! - **Goodbye on the way out.** A stale instance lingering in every browser on

--- a/packages/mbrc-core/src/server/blocked.rs
+++ b/packages/mbrc-core/src/server/blocked.rs
@@ -1,7 +1,7 @@
 //! In-memory log of recently rejected connection attempts, surfaced to the
 //! settings panel so a user can see why a device was blocked (issue #84).
 //!
-//! A bounded ring buffer of the last [`MAX_ENTRIES`] rejections, newest first.
+//! A bounded ring buffer of the last `MAX_ENTRIES` rejections, newest first.
 //! Not persisted - it resets when the plugin reloads (the reject reasons are a
 //! live-debugging aid, not an audit log). Populated at the accept-loop /
 //! connection reject sites (`server::accept_loop`, `connection::run`) and read

--- a/packages/mbrc-core/src/server/registry.rs
+++ b/packages/mbrc-core/src/server/registry.rs
@@ -178,7 +178,7 @@ impl ConnectionRegistry {
     /// sockets the newcomer carries the user's request and the held sockets are
     /// the abandoned ones, so refusing it made iOS lock itself out. The victim is
     /// the least recently active non-subscriber from that IP, silent for at least
-    /// [`MIN_EVICT_IDLE_MS`]; its slot frees when its task finishes, so the count
+    /// `MIN_EVICT_IDLE_MS`; its slot frees when its task finishes, so the count
     /// sits one over the cap until then.
     pub fn admit_ip(&self, ip: IpAddr) -> IpAdmit {
         if ip.is_loopback() {

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -110,7 +110,7 @@ impl Core {
     }
 
     /// Whether teardown has started. Checked between items by work that would
-    /// otherwise hold MusicBee's shutdown - see [`Core::stopping`].
+    /// otherwise hold MusicBee's shutdown - see the `stopping` flag.
     pub fn is_stopping(&self) -> bool {
         self.stopping.load(Ordering::Acquire)
     }

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -4,7 +4,7 @@
 //! the helper it is about to run is the one the release signed, and launches it.
 //! What may be passed to the helper, what is verified before it runs, and what
 //! counts as an upgrade are pinned by the tests at the foot of this file; why
-//! the verification still holds at launch time is on [`VerifiedHelper`].
+//! the verification still holds at launch time is on `VerifiedHelper`.
 //!
 //! The one rule nothing else records: elevation is asked for **now**, not later.
 //! `runas` prompts while the user is still looking at the button they pressed. A

--- a/packages/mbrc-core/src/updates/mod.rs
+++ b/packages/mbrc-core/src/updates/mod.rs
@@ -6,7 +6,7 @@
 //! reports over FFI.
 //!
 //! Nothing here reaches the network on its own. It takes an
-//! [`HttpClient`](mbrc_release::HttpClient); `http_client` builds the
+//! [`HttpClient`]; `http_client` builds the
 //! production one (WinHTTP) from the user's settings, and [`service`] is what
 //! decides when to hand it one - the panel's buttons and the one check the core
 //! runs shortly after networking starts.


### PR DESCRIPTION
## What

`cargo doc` emitted 9 warnings on `main`, all in `mbrc-core`. Eight were public docs
linking to private items, which rustdoc renders as bare text with no link; one spelled out
a link target the shorthand already resolved to.

| doc site | linked to | which is |
|---|---|---|
| `bundle.rs:31` | `extra_logs` | a private fn |
| `capture.rs:15`, `capture.rs:246` | `MAX_CAPTURE` | a private const |
| `mdns.rs:14` | `usable_ipv4_ifaces` | a private fn |
| `blocked.rs:4` | `MAX_ENTRIES` | a private const |
| `registry.rs:181` | `MIN_EVICT_IDLE_MS` | a private const |
| `state.rs:113` | `Core::stopping` | a private field |
| `elevate.rs:7` | `VerifiedHelper` | a private type |
| `updates/mod.rs:9` | `mbrc_release::HttpClient` | a redundant explicit target |

## How

Plain backticks where the item is an implementation detail a reader finds in the same file -
the constants stay private, since making them `pub` purely to satisfy a link would widen the
API for a doc's benefit. The redundant path in `updates/mod.rs` is dropped.

## CI

The rustdoc step now also denies `rustdoc::private_intra_doc_links` and
`rustdoc::redundant_explicit_links`, so a doc cannot quietly go back to promising a link it
does not deliver. Note the lint is `redundant_explicit_link`**s** - the singular is itself an
`unknown_lint` warning, so the flags were verified by running the exact CI command locally.

## Verification

`cargo doc --no-deps --workspace` with the new `RUSTDOCFLAGS`: **0 warnings**. No behaviour
change - comments only, plus the workflow env.
