### PR TITLE
fix(core): let the library tag cache keep what it built

### DIFF
--- a/packages/mbrc-core/src/server/commands/library.rs
+++ b/packages/mbrc-core/src/server/commands/library.rs
@@ -195,12 +195,12 @@ pub fn build_track_index(cache: &MetadataCache, p: &dyn Providers) -> usize {
 
 /// Refreshes the library caches incrementally (the Scanner's delta pass).
 ///
-/// Rebuilds the ordinal index from the current path list (catches add / delete
-/// / reorder), drops the cached tags of tracks the host reports changed since
-/// the watermark (they re-read lazily), re-prewarms the small lists (an add /
-/// tag edit shifts their counts), and advances the watermark. No-op until the
-/// cache is validated (the init reconcile owns the first build). Best-effort: a
-/// failed provider call leaves that piece stale for the next pass.
+/// Rebuilds the ordinal index, drops the tags of tracks the host reports
+/// changed, re-prewarms the small lists, advances the watermark. No-op until
+/// the cache is validated; best-effort otherwise.
+///
+/// Only `updated` and `deleted` drop tags: `added` is asked for with no cached
+/// file list, which MusicBee answers with the whole library.
 pub fn refresh_library_delta(cache: &MetadataCache, p: &dyn Providers) {
     if !cache.is_validated() {
         return;
@@ -213,12 +213,9 @@ pub fn refresh_library_delta(cache: &MetadataCache, p: &dyn Providers) {
         Err(e) => tracing::warn!(error = %e, "scanner: track path refetch failed"),
     }
 
-    // `added` are not cached yet, `updated` are the ones that matter, and
-    // `deleted` clears tag rows the index rebuild orphaned.
     match p.sync_delta(since) {
         Ok(delta) => {
             let mut changed = delta.updated;
-            changed.extend(delta.added);
             changed.extend(delta.deleted);
             cache.drop_track_tags(&changed);
         }
@@ -770,6 +767,50 @@ mod tests {
         assert!(cache.tracks_synced_at() > 100);
         assert!(m.recorded().contains(&"sync_delta(100)".to_string()));
         assert!(m.recorded().contains(&"track_paths".to_string()));
+    }
+
+    /// The host is asked for the delta with no cached file list, which it
+    /// answers by calling the whole library new. Dropping tags for that emptied
+    /// the cache on every pass, so nothing a browse had filled ever survived.
+    #[test]
+    fn a_delta_that_calls_everything_new_keeps_the_cached_tags() {
+        use crate::metadata_cache::MetadataCache;
+        use crate::protocol::messages::SyncDelta;
+        use crate::store::Db;
+
+        let dir = std::env::temp_dir().join("mbrc-delta-all-new");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache = MetadataCache::new(Db::open(dir.to_str().unwrap()));
+        cache.reconcile(1);
+
+        cache.replace_track_index(&["/a.mp3".into(), "/b.mp3".into()]);
+        cache.put_track_tags(&[
+            Track {
+                src: "/a.mp3".into(),
+                title: "A".into(),
+                ..Default::default()
+            },
+            Track {
+                src: "/b.mp3".into(),
+                title: "B".into(),
+                ..Default::default()
+            },
+        ]);
+
+        let m = MockProviders {
+            track_paths: vec!["/a.mp3".into(), "/b.mp3".into()],
+            sync_delta: SyncDelta {
+                added: vec!["/a.mp3".into(), "/b.mp3".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        refresh_library_delta(&cache, &m);
+
+        assert!(cache.track_tags("/a.mp3").is_some(), "kept what it built");
+        assert!(cache.track_tags("/b.mp3").is_some(), "kept what it built");
     }
 
     #[test]

--- a/packages/mbrc-core/src/server/scanner.rs
+++ b/packages/mbrc-core/src/server/scanner.rs
@@ -45,13 +45,13 @@ pub async fn run(core: Arc<Core>, shutdown: Arc<Notify>) {
                 scan_after_a_library_change(&core).await;
             }
             _ = interval.tick() => {
-                if core.broadcaster.client_count() > 0 {
+                if subscribers(&core) > 0 {
                     // Debug-gated, so the syscall is skipped when filtered out.
                     // Should stay flat under a paging sweep: the cache is O(page).
                     tracing::debug!(
                         rss_mib = crate::logging::rss_mib(),
                         tracks = core.metadata_cache.track_count(),
-                        clients = core.broadcaster.client_count(),
+                        clients = subscribers(&core),
                         "core memory sample"
                     );
                     scan_periodically(&core).await;
@@ -59,6 +59,16 @@ pub async fn run(core: Arc<Core>, shutdown: Arc<Notify>) {
             }
         }
     }
+}
+
+/// Clients subscribed to broadcasts, on either protocol.
+///
+/// Both, because a V6 client registers with the V6 broadcaster alone: counting
+/// only the legacy one made a session with nothing but V6 clients look idle, and
+/// the periodic pass - the safety net for changes no notification covered -
+/// never ran.
+fn subscribers(core: &Arc<Core>) -> usize {
+    core.broadcaster.client_count() + core.v6_broadcaster.client_count()
 }
 
 /// A delta pass prompted by an explicit change signal.
@@ -104,4 +114,29 @@ async fn scan(core: &Arc<Core>, covers: bool) {
             .emit_event(HostEventType::CacheStatusChanged, &[]);
     })
     .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::providers::NullProviders;
+    use tokio::sync::mpsc;
+
+    /// A V6 client registers with the V6 broadcaster alone. Counting only the
+    /// legacy one made a V6-only session look idle, so the periodic pass - the
+    /// safety net for changes no notification covered - never ran.
+    #[test]
+    fn a_v6_only_session_counts_as_connected() {
+        let core = Arc::new(Core::new(Arc::new(NullProviders), Config::for_test(0)));
+        assert_eq!(subscribers(&core), 0);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        core.v6_broadcaster.register(1, tx);
+        assert_eq!(subscribers(&core), 1, "a V6 subscriber is a client");
+
+        let (tx4, _rx4) = mpsc::unbounded_channel();
+        core.broadcaster.register(2, tx4);
+        assert_eq!(subscribers(&core), 2, "both protocols count");
+    }
 }


### PR DESCRIPTION
Two ways the library tag cache was emptied or never filled, both found while
building the web client and both present on `main` today. Neither is web
specific.

### The delta pass dropped everything it had, every 60s

`refresh_library_delta` asks the host what changed since the watermark and drops
the cached tags of everything named, `added` included. The host is asked with no
cached file list, which MusicBee answers by calling **every file in the library
new** - so the pass dropped every cached tag on every run, for as long as a
client stayed connected.

Nothing a browse had filled ever survived a minute. Only `updated` and `deleted`
drop tags now.

### The pass only ran for legacy clients

`scanner::run` gated the periodic pass on `core.broadcaster.client_count()`. A V6
client registers with the V6 broadcaster alone, so a session with nothing but V6
clients (the CLI, the debugger, a browser) looked idle and the safety net for
changes no notification covered never ran at all. Both broadcasters count.

### Tests

Two regression tests, one per bug. 369 core tests pass; clippy clean on
`i686-pc-windows-msvc`.
