### PR TITLE
fix(core): stop the wire captures switching each other off

### DIFF
--- a/packages/mbrc-core/src/logging.rs
+++ b/packages/mbrc-core/src/logging.rs
@@ -509,9 +509,19 @@ pub mod test_support {
         }
     }
 
+    /// Held for the length of a capture, so only one runs at a time.
+    ///
+    /// `with_default` raises tracing's global maximum level on entry and puts it
+    /// back when its guard drops. That maximum is what `enabled!` consults, so a
+    /// capture finishing on one thread switches the wire logging off under a
+    /// capture still running on another, which comes back holding nothing.
+    static CAPTURING: Mutex<()> = Mutex::new(());
+
     /// Runs `f` with a subscriber that captures every `mbrc::wire` event at DEBUG
     /// and above, and return what it captured.
     pub fn capture_wire_lines(f: impl FnOnce()) -> Vec<WireLine> {
+        // A panic in one capture must not stop the rest from running.
+        let _serialised = CAPTURING.lock().unwrap_or_else(|held| held.into_inner());
         let lines = Arc::new(Mutex::new(Vec::new()));
         let layer = CaptureLayer {
             lines: Arc::clone(&lines),


### PR DESCRIPTION
The wire-line captures in `logging.rs` switch each other off when two run at
once, so a capture can come back holding nothing and its test fails on an
assertion against an empty list.

`with_default` raises tracing's global maximum level on entry and puts it back
when its guard drops. That maximum is what `enabled!` consults, so a capture
finishing on one thread turns the wire logging off under a capture still running
on another. A capture now holds a lock for its length.

Seen on a Windows runner at roughly one run in three, and reproduced locally in
a worktree that did not have the fix: `broadcast_logs_one_line_per_frame_with_
subscriber_count` failed with `assertion failed: []`, then passed alone and on
every re-run.

The fix was written on `feat/web-app` and is being pulled out ahead of it,
because it is a bug on main today and every PR pays for it.
