### PR TITLE
fix: count what is left to play, not the page that was sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Change Log
   before. See `docs/protocol-v6.md`.
 
 ### Fixed
+- The browser client's Up Next list stopped at 200 tracks and would not scroll
+  further, because the queue reported the size of the page it had just sent as
+  the number of tracks left to play.
 - Library browsing could show almost nothing for an album but its name. The cache
   emptied every tag it held roughly once a minute for as long as a client stayed
   connected, and what the browse path wrote back in its place had no year, rating

--- a/docs/protocol-v6.md
+++ b/docs/protocol-v6.md
@@ -471,6 +471,10 @@ One canonical list (no per-client-type variants). Each item is the
 - **`up_next: true`**: MusicBee's shuffle-aware **play order from the current track**; already-played
   tracks are dropped. `order` is the true storage index; `position == play_position`.
 
+In both views **`total` is the number of tracks the view holds**, not the size of the page:
+the whole queue by default, and everything still to play under `up_next`. Page it the same
+way in either.
+
 | Op | Request `data` | Response |
 |----|----------------|----------|
 | `now_playing_list` | `{offset?, limit?, up_next?, totals?}` | `{total, offset, version, items}` - canonical tracks + `order` + `position` + `play_position` |
@@ -481,12 +485,10 @@ One canonical list (no per-client-type variants). Each item is the
 | `now_playing_list_search` | `{"query":"<text>"}` | `{}` |
 | `now_playing_queue` | `{"paths":[..],"mode?":"next"\|"last"\|"now"\|"add_all","play?":"<path>"}` | `{}` |
 
-`totals: true` adds **`total_duration_ms`**: the whole queue in the default view, and under
-`up_next` everything still to play, whatever `limit` the page asked for. (`total` under
-`up_next` reports the walk the window covers, so the two do not match there; the run time is
-the one that describes the view.) Opt-in because it is the answer a window cannot give - it
-reads the tags of the whole list, where a plain page reads only the rows it serves. A track
-the host reports no duration for counts as nothing.
+`totals: true` adds **`total_duration_ms`**, how long what `total` counts runs: the whole
+queue in the default view, everything still to play under `up_next`. Opt-in because it is the
+answer a window cannot give - it reads the tags of the whole list, where a plain page reads
+only the rows it serves. A track the host reports no duration for counts as nothing.
 
 **`version` and the mutation guard.** MusicBee addresses the queue by index alone, so an
 `order` only means what you read while the list it came from still holds. Every page carries

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -181,6 +181,10 @@ pub enum QueryType {
     // paths-only enumeration. The page query reads tags for its window, which
     // cannot answer how long the whole queue runs.
     NowPlayingListPaths = 40,
+    // The play order from the current track, as indices and paths, without tag
+    // reads. The ordered page walks the same sequence but reports the length of
+    // the window it served, which cannot say how much is left to play.
+    NowPlayingListOrder = 41,
 }
 
 /// Command types for the fat `execute_command` callback (C# mutates state).

--- a/packages/mbrc-core/src/protocol/messages.rs
+++ b/packages/mbrc-core/src/protocol/messages.rs
@@ -403,6 +403,21 @@ pub struct Playlist {
     pub name: String,
 }
 
+/// The queue's play order from the current track, as indices and paths.
+///
+/// The same forward walk the ordered page makes, without reading a tag: how long
+/// the walk is, which storage slot each step lands on, and what is filed there.
+/// Every question about the play order as a whole is answered from this, so none
+/// of them costs a walk that reads tags it will not use.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NowPlayingOrder {
+    /// Storage index per step, in play order (`positions[0]` is the current track).
+    #[serde(default)]
+    pub positions: Vec<i32>,
+    #[serde(default)]
+    pub paths: Vec<String>,
+}
+
 /// A playlist's files in playlist order, with the playlist's own name.
 ///
 /// Paths only: tags are read for the served page alone, so the size of this

--- a/packages/mbrc-core/src/providers.rs
+++ b/packages/mbrc-core/src/providers.rs
@@ -19,9 +19,9 @@ use crate::ffi::dtos::{
 use crate::ffi::types::{CommandType, QueryType};
 use crate::protocol::messages::{
     AlbumCover, AlbumCoverItem, AlbumData, AlbumIdentifier, ArtistData, Cover, GenreData,
-    LastfmStatus, Lyrics, NowPlayingListTrack, OutputDevices, Page, PlaybackPositionResponse,
-    PlayerState, Playlist, PlaylistFiles, QueueType, RadioStation, RepeatMode, SyncDelta, Track,
-    TrackDetails, TrackInfo, TrackMetadata, TrackTags,
+    LastfmStatus, Lyrics, NowPlayingListTrack, NowPlayingOrder, OutputDevices, Page,
+    PlaybackPositionResponse, PlayerState, Playlist, PlaylistFiles, QueueType, RadioStation,
+    RepeatMode, SyncDelta, Track, TrackDetails, TrackInfo, TrackMetadata, TrackTags,
 };
 
 /// The MusicBee data/command surface, as the core sees it. Handlers take
@@ -88,6 +88,11 @@ pub trait Providers: Send + Sync {
     /// The page queries read tags for the window they serve, so neither can
     /// answer a question about the whole queue.
     fn now_playing_list_paths(&self) -> Result<Vec<String>, String>;
+    /// The whole play order from the current track, without reading a tag.
+    ///
+    /// The ordered page reports the length of the window it served, so it cannot
+    /// say how much is left to play.
+    fn now_playing_list_order(&self) -> Result<NowPlayingOrder, String>;
     fn play_list_item(&self, index: i32) -> Result<(), String>;
     fn remove_list_item(&self, index: i32) -> Result<(), String>;
     fn move_list_item(&self, from: i32, to: i32) -> Result<(), String>;
@@ -313,6 +318,10 @@ impl Providers for FfiProviders {
     fn now_playing_list_paths(&self) -> Result<Vec<String>, String> {
         self.callbacks
             .query_no_params(QueryType::NowPlayingListPaths)
+    }
+    fn now_playing_list_order(&self) -> Result<NowPlayingOrder, String> {
+        self.callbacks
+            .query_no_params(QueryType::NowPlayingListOrder)
     }
     fn play_list_item(&self, index: i32) -> Result<(), String> {
         self.callbacks
@@ -625,6 +634,9 @@ impl Providers for NullProviders {
     fn now_playing_list_paths(&self) -> Result<Vec<String>, String> {
         Ok(Vec::new())
     }
+    fn now_playing_list_order(&self) -> Result<NowPlayingOrder, String> {
+        Ok(NowPlayingOrder::default())
+    }
     fn play_list_item(&self, _index: i32) -> Result<(), String> {
         Ok(())
     }
@@ -746,6 +758,7 @@ pub struct MockProviders {
     pub now_playing_list: Page<NowPlayingListTrack>,
     pub now_playing_list_ordered: Page<NowPlayingListTrack>,
     pub now_playing_list_paths: Vec<String>,
+    pub now_playing_list_order: NowPlayingOrder,
     pub browse_genres: Page<GenreData>,
     pub browse_artists: Page<ArtistData>,
     pub browse_albums: Page<AlbumData>,
@@ -919,6 +932,10 @@ impl Providers for MockProviders {
     fn now_playing_list_paths(&self) -> Result<Vec<String>, String> {
         self.record("now_playing_list_paths");
         Ok(self.now_playing_list_paths.clone())
+    }
+    fn now_playing_list_order(&self) -> Result<NowPlayingOrder, String> {
+        self.record("now_playing_list_order");
+        Ok(self.now_playing_list_order.clone())
     }
     fn play_list_item(&self, index: i32) -> Result<(), String> {
         self.record(format!("play_list_item({index})"));

--- a/packages/mbrc-core/src/server/commands_v6/nowplaying_list.rs
+++ b/packages/mbrc-core/src/server/commands_v6/nowplaying_list.rs
@@ -29,7 +29,7 @@ use super::{
 use crate::cover::store::CoverStore;
 use crate::metadata_cache::MetadataCache;
 use crate::nowplaying::NowPlayingCache;
-use crate::protocol::messages::{NowPlayingListTrack, QueueType, TrackTags};
+use crate::protocol::messages::{NowPlayingListTrack, NowPlayingOrder, QueueType, TrackTags};
 use crate::providers::Providers;
 use mbrc_wire::v6::ErrorCode;
 
@@ -68,6 +68,10 @@ pub fn dispatch(
 /// The now-playing queue as a `Page` of canonical tracks.
 ///
 /// The two views and the three per-item indices are described on the module.
+///
+/// Under `up_next`, `total` is the length of the play order rather than what the
+/// host's ordered page reports, which counts only the window it served: a client
+/// paging that view was told it held everything after its first page.
 fn list(
     data: &Value,
     p: &dyn Providers,
@@ -85,10 +89,12 @@ fn list(
     }
     .map_err(internal)?;
 
-    let play_rank = if up_next {
-        HashMap::new()
+    let order = p.now_playing_list_order().map_err(internal)?;
+    let play_rank = play_ranks(&order);
+    let total = if up_next {
+        order.positions.len()
     } else {
-        play_ranks(p)?
+        page.total.max(0) as usize
     };
 
     // A path the library cannot resolve (a queued external file) falls back to
@@ -126,10 +132,10 @@ fn list(
             obj
         })
         .collect();
-    let mut out = page_json(page.total.max(0) as usize, offset, items);
+    let mut out = page_json(total, offset, items);
     out["version"] = json!(list_version(now_playing));
     if totals {
-        out["total_duration_ms"] = json!(run_time_ms(p, cache, up_next)?);
+        out["total_duration_ms"] = json!(run_time_ms(p, cache, up_next, &order)?);
     }
     Ok(out)
 }
@@ -146,14 +152,10 @@ fn run_time_ms(
     p: &dyn Providers,
     cache: Option<&MetadataCache>,
     up_next: bool,
+    order: &NowPlayingOrder,
 ) -> Result<i64, V6Error> {
-    let paths: Vec<String> = if up_next {
-        p.now_playing_list_ordered(0, 0)
-            .map_err(internal)?
-            .data
-            .into_iter()
-            .map(|npt| npt.path)
-            .collect()
+    let paths = if up_next {
+        order.paths.clone()
     } else {
         p.now_playing_list_paths().map_err(internal)?
     };
@@ -201,18 +203,15 @@ fn guarded(
 
 /// Storage index to shuffle play rank, for the list-order view.
 ///
-/// The forward walk carries the storage index in `position`, and its ordinal is
-/// the play rank; a track missing from the walk has been played and gets -1 at
-/// the call site. Indices only, but the walk still reads tags - queues are small
-/// enough that an indices-only provider has not been worth adding.
-fn play_ranks(p: &dyn Providers) -> Result<HashMap<i32, i64>, V6Error> {
-    Ok(p.now_playing_list_ordered(0, 0)
-        .map_err(internal)?
-        .data
+/// The walk's ordinal is the play rank; a track missing from it has been played
+/// and gets -1 at the call site.
+fn play_ranks(order: &NowPlayingOrder) -> HashMap<i32, i64> {
+    order
+        .positions
         .iter()
         .enumerate()
-        .map(|(rank, npt)| (npt.position, rank as i64))
-        .collect())
+        .map(|(rank, position)| (*position, rank as i64))
+        .collect()
 }
 
 /// A minimal canonical-shaped track from the now-playing item's basic fields, for
@@ -302,6 +301,14 @@ mod tests {
     use crate::protocol::messages::Page;
     use crate::providers::MockProviders;
 
+    /// The play order as the host reports it: storage index and path per step.
+    fn order(steps: &[(&str, i32)]) -> NowPlayingOrder {
+        NowPlayingOrder {
+            positions: steps.iter().map(|(_, i)| *i).collect(),
+            paths: steps.iter().map(|(p, _)| (*p).to_string()).collect(),
+        }
+    }
+
     fn npt(path: &str, position: i32) -> NowPlayingListTrack {
         NowPlayingListTrack {
             path: path.into(),
@@ -322,12 +329,7 @@ mod tests {
             },
             // Forward play order = only b remains upcoming (storage index 1),
             // so a (storage 0) is already played -> play_position -1.
-            now_playing_list_ordered: Page {
-                total: 1,
-                offset: 0,
-                limit: 0,
-                data: vec![npt("b.mp3", 1)],
-            },
+            now_playing_list_order: order(&[("b.mp3", 1)]),
             tracks_detailed: vec![TrackTags {
                 src: "a.mp3".into(),
                 title: "Resolved A".into(),
@@ -367,6 +369,7 @@ mod tests {
                 limit: 0,
                 data: vec![npt("x.mp3", 5), npt("y.mp3", 2)],
             },
+            now_playing_list_order: order(&[("x.mp3", 5), ("y.mp3", 2)]),
             ..Default::default()
         };
         let out = dispatch(
@@ -393,6 +396,34 @@ mod tests {
         assert_eq!(out["items"][1]["play_position"], 1);
     }
 
+    /// The host's ordered page counts what it served, so a limited up-next page
+    /// used to report its own size as the total and a client stopped paging.
+    #[test]
+    fn up_next_counts_the_whole_play_order_not_the_page() {
+        let m = MockProviders {
+            now_playing_list_ordered: Page {
+                total: 2,
+                offset: 0,
+                limit: 2,
+                data: vec![npt("x.mp3", 5), npt("y.mp3", 2)],
+            },
+            now_playing_list_order: order(&[("x.mp3", 5), ("y.mp3", 2), ("z.mp3", 7)]),
+            ..Default::default()
+        };
+        let out = dispatch(
+            "now_playing_list",
+            &json!({ "up_next": true, "limit": 2 }),
+            &m,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(out["total"], 3);
+        assert_eq!(out["items"].as_array().unwrap().len(), 2);
+    }
+
     #[test]
     fn default_view_offsets_order_position_and_play_position() {
         // A page at offset 5: order/position are the absolute storage indices
@@ -405,12 +436,7 @@ mod tests {
                 data: vec![npt("f.mp3", 5), npt("g.mp3", 6)],
             },
             // Play order: g (storage 6) is current, f (storage 5) is next.
-            now_playing_list_ordered: Page {
-                total: 2,
-                offset: 0,
-                limit: 0,
-                data: vec![npt("g.mp3", 6), npt("f.mp3", 5)],
-            },
+            now_playing_list_order: order(&[("g.mp3", 6), ("f.mp3", 5)]),
             ..Default::default()
         };
         let out = dispatch(
@@ -602,12 +628,7 @@ mod tests {
     #[test]
     fn the_up_next_run_time_covers_the_walk_rather_than_the_queue() {
         let m = MockProviders {
-            now_playing_list_ordered: Page {
-                total: 1,
-                offset: 0,
-                limit: 0,
-                data: vec![npt("b.mp3", 1)],
-            },
+            now_playing_list_order: order(&[("b.mp3", 1)]),
             now_playing_list_paths: vec!["a.mp3".into(), "b.mp3".into()],
             tracks_detailed: vec![
                 TrackTags {

--- a/packages/mbrc-core/tests/common/mod.rs
+++ b/packages/mbrc-core/tests/common/mod.rs
@@ -192,6 +192,13 @@ impl Providers for FixtureProviders {
     ) -> Result<Page<NowPlayingListTrack>, String> {
         self.now_playing_list(o, l)
     }
+    fn now_playing_list_order(&self) -> Result<NowPlayingOrder, String> {
+        let data = self.now_playing_list(0, 0)?.data;
+        Ok(NowPlayingOrder {
+            positions: data.iter().map(|t| t.position).collect(),
+            paths: data.into_iter().map(|t| t.path).collect(),
+        })
+    }
     fn now_playing_list_paths(&self) -> Result<Vec<String>, String> {
         Ok(self
             .now_playing_list(0, 0)?

--- a/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
@@ -192,6 +192,12 @@ namespace MusicBeePlugin.Ffi
         public string name { get; set; }
     }
 
+    public class NowPlayingOrder
+    {
+        public List<int> positions { get; set; }
+        public List<string> paths { get; set; }
+    }
+
     public class PlaylistFiles
     {
         public string name { get; set; }

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -85,6 +85,7 @@ namespace MusicBeePlugin.Ffi.Generated
         LibraryGenreTracks = 38,
         PlaylistTracks = 39,
         NowPlayingListPaths = 40,
+        NowPlayingListOrder = 41,
     }
 
     public enum CommandType

--- a/packages/plugin/Ffi/QueryHandlers.cs
+++ b/packages/plugin/Ffi/QueryHandlers.cs
@@ -63,6 +63,7 @@ namespace MusicBeePlugin.Ffi
                 case QueryType.NowPlayingList: return Pack(BuildNowPlayingList(Page(p), ordered: false));
                 case QueryType.NowPlayingListOrdered: return Pack(BuildNowPlayingList(Page(p), ordered: true));
                 case QueryType.NowPlayingListPaths: return Pack(_track.GetNowPlayingListPaths());
+                case QueryType.NowPlayingListOrder: return Pack(_track.GetNowPlayingListOrder());
                 case QueryType.RadioStations: return Pack(BuildRadioStations(Page(p)));
                 case QueryType.LibraryBrowseGenres: return Pack(BuildBrowseGenres(Page(p)));
                 case QueryType.LibraryBrowseArtists: return Pack(BuildBrowseArtists(Msgpack.Deserialize<BrowseParams>(p)));

--- a/packages/plugin/Providers/ITrackDataProvider.cs
+++ b/packages/plugin/Providers/ITrackDataProvider.cs
@@ -102,6 +102,14 @@ namespace MusicBeePlugin.Providers
         /// </summary>
         string[] GetNowPlayingListPaths();
 
+        /// <summary>
+        ///     The play order from the current track: one storage index and path
+        ///     per step, no tag reads. <see cref="GetNowPlayingListOrdered" />
+        ///     walks the same sequence but reads tags, so it cannot be asked how
+        ///     long the walk is without paying for a window nobody wanted.
+        /// </summary>
+        NowPlayingOrder GetNowPlayingListOrder();
+
         // Rating Operations
 
         /// <summary>

--- a/packages/plugin/Providers/TrackDataProvider.cs
+++ b/packages/plugin/Providers/TrackDataProvider.cs
@@ -267,6 +267,27 @@ namespace MusicBeePlugin.Providers
             }
         }
 
+        public NowPlayingOrder GetNowPlayingListOrder()
+        {
+            var order = new NowPlayingOrder { positions = new List<int>(), paths = new List<string>() };
+            if (!_api.NowPlayingList_QueryFiles(null))
+                return order;
+
+            var position = 1;
+            var itemIndex = _api.NowPlayingList_GetCurrentIndex();
+            while (true)
+            {
+                var trackPath = _api.NowPlayingList_GetListFileUrl(itemIndex);
+                if (string.IsNullOrEmpty(trackPath))
+                    return order;
+
+                order.positions.Add(itemIndex);
+                order.paths.Add(trackPath);
+                itemIndex = _api.NowPlayingList_GetNextIndex(position);
+                position++;
+            }
+        }
+
         public IEnumerable<NowPlayingListTrack> GetNowPlayingListPage(int offset, int limit)
         {
             if (!_api.NowPlayingList_QueryFiles(null))


### PR DESCRIPTION
The browser client's Up Next list stopped at 200 tracks and would not scroll
further. Found while testing #215, and unrelated to it.

## What was wrong

The host's ordered walk is paged, and it reports the length of the walk it
served as the page's total. Ask for 200 rows and it answers `total: 200`,
whatever is behind them. A client comparing what it holds against the total is
then told, after its very first page, that it holds everything.

The default view was never affected: it reports the real queue count.

## The fix

V6 takes the count from the play order itself. The host gained a query that
walks the queue by index and returns one storage index and path per step,
reading no tags at all; the count is that walk's length.

V4 still reads the page's own total, so its frames are unchanged.

The same walk then answers two questions that each cost a full tag-reading pass
before:

- the play-order ranks every default page carries (`play_position`), which
  walked the whole queue reading tags it threw away;
- the up-next run time from #215.

So the default queue page got cheaper as a side effect.

## Verified live

402 tracks queued, against a running MusicBee:

| request | before | now |
|---|---|---|
| `{up_next, limit:200}` | `total: 200`, paging stopped | `total: 401`, 200 items |
| `{up_next, offset:200, limit:200}` | never asked for | 200 items, orders 201+ |
| `{up_next, limit:0}` | 401 | 401 |

The run times agree with each other too: 98,978,000 ms for the walk against
99,319,000 for the whole queue, a difference of 341,000 ms, exactly the 5:41 of
the one track already played.

`up_next_counts_the_whole_play_order_not_the_page` pins it: a three-step play
order served with `limit: 2` must answer `total: 3`.
